### PR TITLE
First draft of Decaf support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ version = "0.3"
 [features]
 default = ["std"]
 std = ["rand"]
+yolocrypto = []
 
 # The development profile, used for `cargo build`.
 [profile.dev]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -29,9 +29,18 @@ pub const d: FieldElement       = FieldElement([
 pub const d2: FieldElement      = FieldElement([
     -21827239,  -5839606, -30745221,  13898782,    229458,
     15978800,  -12551817,  -6495438,  29715968,   9444199, ]);
+
+/// Precomputed value of one of the square roots of -1 (mod p)
 pub const SQRT_M1: FieldElement = FieldElement([
     -32595792,  -7943725,   9377950,   3500415,  12389472,
     -272473,   -25146209,  -2005654,    326686,  11406482, ]);
+
+/// Precomputed value of the other square root of -1 (mod p),
+/// i.e., MSQRT_M1 = -SQRT_M1.
+pub const MSQRT_M1: FieldElement = FieldElement([
+    32595792,    7943725,  -9377950,  -3500415, -12389472,
+    272473,     25146209,   2005654,   -326686, -11406482, ]);
+
 /// Precomputed value of 1/2 (mod p).
 pub const HALF: FieldElement = FieldElement([
     10, 0, 0, 0, 0, 0, 0, 0, 0, -16777216, ]);
@@ -1491,11 +1500,13 @@ mod test {
     }
 
     #[test]
-    /// Test that SQRT_M1 is a square root of -1
+    /// Test that SQRT_M1 and MSQRT_M1 are square roots of -1
     fn test_sqrt_minus_one() {
         let minus_one = FieldElement([-1,0,0,0,0,0,0,0,0,0]);
         let sqrt_m1_sq = &constants::SQRT_M1 * &constants::SQRT_M1;
-        assert_eq!(minus_one, sqrt_m1_sq);
+        let msqrt_m1_sq = &constants::MSQRT_M1 * &constants::MSQRT_M1;
+        assert_eq!(minus_one,  sqrt_m1_sq);
+        assert_eq!(minus_one, msqrt_m1_sq);
     }
 
     #[test]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -29,6 +29,9 @@ pub const d: FieldElement       = FieldElement([
 pub const d2: FieldElement      = FieldElement([
     -21827239,  -5839606, -30745221,  13898782,    229458,
     15978800,  -12551817,  -6495438,  29715968,   9444199, ]);
+pub const d4: FieldElement      = FieldElement([
+    23454405,  -11679213,   5618422,  -5756869,    458917,
+    -1596832,  -25103633, -12990876,  -7676928, -14666033  ]);
 
 /// Precomputed value of one of the square roots of -1 (mod p)
 pub const SQRT_M1: FieldElement = FieldElement([
@@ -1518,6 +1521,13 @@ mod test {
         let d2 = &d + &d;
         assert_eq!(d, constants::d);
         assert_eq!(d2, constants::d2);
+    }
+
+    #[test]
+    fn test_d4() {
+        let mut four = FieldElement::zero();
+        four[0] = 4;
+        assert_eq!(&constants::d * &four, constants::d4);
     }
 
     /// Test the values in the lookup table of precomputed multiples

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -32,6 +32,9 @@ pub const d2: FieldElement      = FieldElement([
 pub const d4: FieldElement      = FieldElement([
     23454405,  -11679213,   5618422,  -5756869,    458917,
     -1596832,  -25103633, -12990876,  -7676928, -14666033  ]);
+pub const a_minus_d: FieldElement    = FieldElement([
+    10913609,  -13857413,  15372611,  -6949391,   -114729,
+     8787816,    6275908,   3247719,  18696448,  12055116, ]);
 
 /// Precomputed value of one of the square roots of -1 (mod p)
 pub const SQRT_M1: FieldElement = FieldElement([
@@ -1528,6 +1531,13 @@ mod test {
         let mut four = FieldElement::zero();
         four[0] = 4;
         assert_eq!(&constants::d * &four, constants::d4);
+    }
+
+    #[test]
+    fn test_a_minus_d() {
+        let a = FieldElement([-1,0,0,0,0,0,0,0,0,0]);
+        let a_minus_d = &a - &constants::d;
+        assert_eq!(a_minus_d, constants::a_minus_d);
     }
 
     /// Test the values in the lookup table of precomputed multiples

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -36,6 +36,13 @@ pub const a_minus_d: FieldElement    = FieldElement([
     10913609,  -13857413,  15372611,  -6949391,   -114729,
      8787816,    6275908,   3247719,  18696448,  12055116, ]);
 
+/// (p-1)/2, in little-endian bytes.
+pub const HALF_P_MINUS_1_BYTES: [u8; 32] =
+    [0xf6, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f];
+
 /// Precomputed value of one of the square roots of -1 (mod p)
 pub const SQRT_M1: FieldElement = FieldElement([
     -32595792,  -7943725,   9377950,   3500415,  12389472,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1573,6 +1573,7 @@ mod test {
     use curve::CompressedEdwardsY;
     use curve::ExtendedPoint;
     use curve::Identity;
+    use curve::IsIdentity;
     use curve::ValidityCheck;
     use constants;
 
@@ -1584,7 +1585,7 @@ mod test {
         for i in 0..8 {
             let Q = constants::EIGHT_TORSION[i].mult_by_pow_2(3);
             assert!(Q.is_valid());
-            assert!(Q.compress() == compressed_id);
+            assert!(Q.is_identity());
         }
     }
 
@@ -1596,7 +1597,7 @@ mod test {
         for i in (0..8).filter(|i| i % 2 == 0) {
             let Q = constants::EIGHT_TORSION[i].mult_by_pow_2(2);
             assert!(Q.is_valid());
-            assert!(Q.compress() == compressed_id);
+            assert!(Q.is_identity());
         }
     }
 
@@ -1608,7 +1609,7 @@ mod test {
         for i in (0..8).filter(|i| i % 4 == 0) {
             let Q = constants::EIGHT_TORSION[i].mult_by_pow_2(1);
             assert!(Q.is_valid());
-            assert!(Q.compress() == compressed_id);
+            assert!(Q.is_identity());
         }
     }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -17,8 +17,10 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(missing_docs)]
+#![allow(non_snake_case)]
 
 use field::FieldElement;
+use curve::ExtendedPoint;
 use curve::PreComputedPoint;
 use curve::CompressedEdwardsY;
 use scalar::Scalar;
@@ -105,6 +107,63 @@ pub const lminus1: Scalar = Scalar([ 0xec, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0
                                      0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
                                      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10 ]);
+/// The 8-torsion subgroup Ɛ[8].
+///
+/// In the case of Curve25519, it is cyclic; the `i`th element of the
+/// array is `i*P`, where `P` is a point of order 8 generating Ɛ[8].
+///
+/// Thus Ɛ[4] is the points indexed by 0,2,4,6 and Ɛ[2] is the points
+/// indexed by 0,4. 
+pub const EIGHT_TORSION: [ExtendedPoint; 8] = [
+    ExtendedPoint{
+        X: FieldElement([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Y: FieldElement([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Z: FieldElement([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    },
+    ExtendedPoint{
+        X: FieldElement([21352778, 5345713, 4660180, -8347857, 24143090, 14568123, 30185756, -12247770, -33528939, 8345319]),
+        Y: FieldElement([6952922, 1265500, -6862341, 7057498, 4037696, 5447722, -31680899, 15325402, 19365852, -1569102]),
+        Z: FieldElement([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement([-25262188, -11972680, 11716002, -5869612, -18193162, 16297739, 20670665, -8559098, 3541543, -5011181])
+    },
+    ExtendedPoint{
+        X: FieldElement([32595792, 7943725, -9377950, -3500415, -12389472, 272473, 25146209, 2005654, -326686, -11406482]),
+        Y: FieldElement([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Z: FieldElement([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    },
+    ExtendedPoint{
+        X: FieldElement([21352778, 5345713, 4660180, -8347857, 24143090, 14568123, 30185756, -12247770, -33528939, 8345319]),
+        Y: FieldElement([-6952922, -1265500, 6862341, -7057498, -4037696, -5447722, 31680899, -15325402, -19365852, 1569102]),
+        Z: FieldElement([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement([25262188, 11972680, -11716002, 5869612, 18193162, -16297739, -20670665, 8559098, -3541543, 5011181])
+    },
+    ExtendedPoint{
+        X: FieldElement([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Y: FieldElement([-1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Z: FieldElement([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    },
+    ExtendedPoint{
+        X: FieldElement([-21352778, -5345713, -4660180, 8347857, -24143090, -14568123, -30185756, 12247770, 33528939, -8345319]),
+        Y: FieldElement([-6952922, -1265500, 6862341, -7057498, -4037696, -5447722, 31680899, -15325402, -19365852, 1569102]),
+        Z: FieldElement([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement([-25262188, -11972680, 11716002, -5869612, -18193162, 16297739, 20670665, -8559098, 3541543, -5011181])
+    },
+    ExtendedPoint{
+        X: FieldElement([-32595792, -7943725, 9377950, 3500415, 12389472, -272473, -25146209, -2005654, 326686, 11406482]),
+        Y: FieldElement([0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        Z: FieldElement([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement([0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    },
+    ExtendedPoint{
+        X: FieldElement([-21352778, -5345713, -4660180, 8347857, -24143090, -14568123, -30185756, 12247770, 33528939, -8345319]),
+        Y: FieldElement([6952922, 1265500, -6862341, 7057498, 4037696, 5447722, -31680899, 15325402, 19365852, -1569102]),
+        Z: FieldElement([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement([25262188, 11972680, -11716002, 5869612, 18193162, -16297739, -20670665, 8559098, -3541543, 5011181])
+    },
+];
 
 pub const bi: [PreComputedPoint; 8] = [
     PreComputedPoint{
@@ -1503,7 +1562,47 @@ pub const base: [[PreComputedPoint; 8]; 32] = [
 mod test {
     use field::FieldElement;
     use curve::PreComputedPoint;
+    use curve::CompressedEdwardsY;
+    use curve::ExtendedPoint;
+    use curve::Identity;
+    use curve::ValidityCheck;
     use constants;
+
+    #[test]
+    fn test_eight_torsion() {
+        let mut bytes = [0;32];
+        bytes[0] = 1;
+        let compressed_id = CompressedEdwardsY(bytes);
+        for i in 0..8 {
+            let Q = constants::EIGHT_TORSION[i].mult_by_pow_2(3);
+            assert!(Q.is_valid());
+            assert!(Q.compress() == compressed_id);
+        }
+    }
+
+    #[test]
+    fn test_four_torsion() {
+        let mut bytes = [0;32];
+        bytes[0] = 1;
+        let compressed_id = CompressedEdwardsY(bytes);
+        for i in (0..8).filter(|i| i % 2 == 0) {
+            let Q = constants::EIGHT_TORSION[i].mult_by_pow_2(2);
+            assert!(Q.is_valid());
+            assert!(Q.compress() == compressed_id);
+        }
+    }
+
+    #[test]
+    fn test_two_torsion() {
+        let mut bytes = [0;32];
+        bytes[0] = 1;
+        let compressed_id = CompressedEdwardsY(bytes);
+        for i in (0..8).filter(|i| i % 4 == 0) {
+            let Q = constants::EIGHT_TORSION[i].mult_by_pow_2(1);
+            assert!(Q.is_valid());
+            assert!(Q.compress() == compressed_id);
+        }
+    }
 
     #[test]
     fn test_half() {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -94,6 +94,14 @@ pub const BASE_CMPRSSD: CompressedEdwardsY =
                         0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
                         0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66]);
 
+/// Basepoint has y = 4/5.
+pub const BASEPOINT: ExtendedPoint = ExtendedPoint{
+        X: FieldElement([-14297830, -7645148, 16144683, -16471763, 27570974, -2696100, -26142465, 8378389, 20764389, 8758491]),
+        Y: FieldElement([-26843541, -6710886, 13421773, -13421773, 26843546, 6710886, -13421773, 13421773, -26843546, -6710886]),
+        Z: FieldElement([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        T: FieldElement([28827062, -6116119, -27349572, 244363, 8635006, 11264893, 19351346, 13413597, 16611511, -6414980]),
+};
+
 /// `l` is the order of base point, i.e. 2^252 +
 /// 27742317777372353535851937790883648493, in little-endian form
 pub const l: Scalar = Scalar([ 0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1622,6 +1622,19 @@ mod test {
     }
 
     #[test]
+    fn test_sqrt_constants_sign() {
+        let one       = FieldElement([ 1,0,0,0,0,0,0,0,0,0]);
+        let minus_one = FieldElement([-1,0,0,0,0,0,0,0,0,0]);
+        let invsqrt_m1 = minus_one.invsqrt().unwrap();
+        let sign_test_sqrt  = &invsqrt_m1 * &constants::SQRT_M1;
+        let sign_test_msqrt = &invsqrt_m1 * &constants::MSQRT_M1;
+        // XXX it seems we have flipped the sign relative to
+        // the invsqrt function?
+        assert_eq!(sign_test_sqrt, minus_one);
+        assert_eq!(sign_test_msqrt, one);
+    }
+
+    #[test]
     /// Test that d = -121665/121666
     fn test_d_vs_ratio() {
         let a = FieldElement([-121665,0,0,0,0,0,0,0,0,0]);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -32,6 +32,9 @@ pub const d2: FieldElement      = FieldElement([
 pub const SQRT_M1: FieldElement = FieldElement([
     -32595792,  -7943725,   9377950,   3500415,  12389472,
     -272473,   -25146209,  -2005654,    326686,  11406482, ]);
+/// Precomputed value of 1/2 (mod p).
+pub const HALF: FieldElement = FieldElement([
+    10, 0, 0, 0, 0, 0, 0, 0, 0, -16777216, ]);
 
 /// In Montgomery form y² = x³+Ax²+x, Curve25519 has A=486662.
 pub const A: FieldElement       = FieldElement([
@@ -1479,6 +1482,13 @@ mod test {
     use field::FieldElement;
     use curve::PreComputedPoint;
     use constants;
+
+    #[test]
+    fn test_half() {
+        let one = FieldElement([1,0,0,0,0,0,0,0,0,0]);
+        let two = FieldElement([2,0,0,0,0,0,0,0,0,0]);
+        assert_eq!(one, &two * &constants::HALF);
+    }
 
     #[test]
     /// Test that SQRT_M1 is a square root of -1

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -467,7 +467,7 @@ impl CompletedPoint {
 
 impl ProjectivePoint {
     /// Double this point: return self + self
-    fn double(&self) -> CompletedPoint { // Double()
+    pub fn double(&self) -> CompletedPoint { // Double()
         let XX          = self.X.square();
         let YY          = self.Y.square();
         let ZZ2         = self.Z.square2();
@@ -487,7 +487,7 @@ impl ProjectivePoint {
 
 impl ExtendedPoint {
     /// Add this point to itself.
-    fn double(&self) -> ExtendedPoint {
+    pub fn double(&self) -> ExtendedPoint {
         self.to_projective().double().to_extended()
     }
 }

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -80,6 +80,7 @@
 use core::fmt::Debug;
 use core::iter::Iterator;
 use core::ops::{Add, Sub, Neg, Index};
+use core::cmp::{PartialEq, Eq};
 
 use constants;
 use field::FieldElement;
@@ -163,6 +164,48 @@ impl CompressedEdwardsY {
             X = X.neg();
         }
         T = &X * &Y;
+
+        Some(ExtendedPoint{ X: X, Y: Y, Z: Z, T: T })
+    }
+}
+
+/// A point serialized using Mike Hamburg's Decaf scheme.
+///
+/// XXX think about how this API should work
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct DecafPoint(pub [u8; 32]);
+
+impl DecafPoint {
+    /// View this `DecafPoint` as an array of bytes.
+    pub fn to_bytes(&self) -> [u8;32] {
+        self.0
+    }
+
+    /// Attempt to decompress to an `ExtendedPoint`.
+    pub fn decompress(&self) -> Option<ExtendedPoint> {
+        // XXX should decoding be CT ?
+        // XXX should reject unless s = |s|
+        // XXX need to check that xy is nonnegative and reject otherwise
+        let s = FieldElement::from_bytes(&self.0);
+        let ss = s.square();
+        let X = &s + &s;                    // X = 2s
+        let Z = &FieldElement::one() - &ss; // Z = 1+as^2
+        let u = &(&Z * &Z) - &(&constants::d4 * &ss); // u = Z^2 - 4ds^2
+        let uss = &u * &ss;
+        let mut v = match uss.invsqrt() {
+            Some(v) => v,
+            None => return None,
+        };
+        // Now v = 1/sqrt(us^2) if us^2 is a nonzero square, 0 if us^2 is zero.
+        let uv = &v * &u;
+        if uv.is_negative_decaf() == 1u8 {
+            v.negate();
+        }
+        let mut two_minus_Z = -&Z; two_minus_Z[0] += 2;
+        let mut w = &v * &(&s * &two_minus_Z);
+        w.conditional_assign(&FieldElement::one(), s.is_zero());
+        let Y = &w * &Z;
+        let T = &w * &X;
 
         Some(ExtendedPoint{ X: X, Y: Y, Z: Z, T: T })
     }
@@ -423,6 +466,75 @@ impl ExtendedPoint {
     /// Compress this point to `CompressedEdwardsY` format
     pub fn compress(&self) -> CompressedEdwardsY {
         self.to_projective().compress()
+    }
+
+    /// Compress in Decaf format.
+    pub fn compress_decaf(&self) -> DecafPoint {
+        // Q: Do we want to encode twisted or untwisted?
+        //
+        // Notes: 
+        // Recall that the twisted Edwards curve E_{a,d} is of the form
+        //
+        //     ax^2 + y^2 = 1 + dx^2y^2. 
+        //
+        // Internally, we operate on the curve with a = -1, d =
+        // -121665/121666, a.k.a., the twist.  But maybe we would like
+        // to use Decaf on the untwisted curve with a = 1, d =
+        // 121665/121666.  (why? interop?)
+        //
+        // Fix i, a square root of -1 (mod p).
+        //
+        // The map x -> ix is an isomorphism from E_{a,d} to E_{-a,-d}. 
+        // Its inverse is x -> -ix.
+        // let untwisted_X = &self.X * &constants::MSQRT_M1;
+        // etc.
+
+        // Step 0: pre-rotation, needed for Decaf with E[8] = Z/8
+
+        let mut X = self.X;
+        let mut Y = self.Y;
+        let mut XY = self.T;
+
+        // If y nonzero and xy nonnegative, continue.
+        // Otherwise, add Q_6 = (i,0) = constants::EIGHT_TORSION[6]
+        // (x,y) + Q_6 = (iy,ix)
+        // (X:Y:Z:T) + Q_6 = (iY:iX:Z:-T)
+
+        // XXX it should be possible to avoid this inversion, but
+        // let's make sure the code is correct first
+        let xy = &XY * &self.Z.invert();
+        let is_neg_mask = 1u8 & !(Y.is_nonzero() & xy.is_nonnegative_decaf());
+        let iX = &X * &constants::SQRT_M1;
+        let iY = &Y * &constants::SQRT_M1;
+        X.conditional_assign(&iY, is_neg_mask);
+        Y.conditional_assign(&iX, is_neg_mask);
+        let minus_XY = -&XY;
+        XY.conditional_assign(&minus_XY, is_neg_mask);
+
+        // Step 1: Compute r = 1/sqrt((a-d)(Z+Y)(Z-Y))
+        let Z_plus_Y  = &self.Z + &Y;
+        let Z_minus_Y = &self.Z - &Y;
+        let t = &constants::a_minus_d * &(&Z_plus_Y * &Z_minus_Y);
+        // t should always be square (why?)
+        // XXX is it safe to use option types here?
+        let mut r = t.invsqrt().unwrap();
+
+        // Step 2: Compute u = (a-d)r
+        let u = &constants::a_minus_d * &r;
+
+        // Step 3: Negate r if -2uZ is negative.
+        let uZ = &u * &self.Z;
+        let minus_r = -&r;
+        let m2uZ = -&(&uZ + &uZ);
+        let mask = m2uZ.is_negative_decaf();
+        r.conditional_assign(&minus_r, mask);
+
+        // Step 4: Compute s = |u(r(aZX - dYT)+Y)/a|
+        let minus_ZX = -&(&self.Z * &X);
+        let dYT = &constants::d * &(&Y * &XY);
+        let mut s = &u * &(&(&r * &(&minus_ZX - &dYT)) + &Y);
+        s.negate();
+        DecafPoint(s.abs_decaf().to_bytes())
     }
 
     /// Dehomogenize to a PreComputedPoint.
@@ -856,6 +968,12 @@ impl ExtendedPoint {
 // Debug traits
 // ------------------------------------------------------------------------
 
+impl Debug for DecafPoint {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "DecafPoint: {:?}", &self.0[..])
+    }
+}
+
 impl Debug for ExtendedPoint {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "ExtendedPoint(\n\tX: {:?},\n\tY: {:?},\n\tZ: {:?},\n\tT: {:?}\n)",
@@ -898,6 +1016,8 @@ impl Debug for CachedPoint {
 #[cfg(test)]
 mod test {
     use test::Bencher;
+    use rand::OsRng;
+
     use field::FieldElement;
     use scalar::Scalar;
     use subtle::CTAssignable;
@@ -1160,6 +1280,67 @@ mod test {
     #[test]
     fn test_is_identity() {
         assert!(ExtendedPoint::identity().is_identity());
+    }
+
+    #[test]
+    fn test_decaf_decompress_id() {
+        let compressed_id = DecafPoint([0u8; 32]);
+        let id = compressed_id.decompress().unwrap();
+        // This should compress (as ed25519) to the following:
+        let mut bytes = [0u8; 32]; bytes[0] = 1;
+        assert_eq!(id.compress(), CompressedEdwardsY(bytes));
+    }
+
+    #[test]
+    fn test_decaf_compress_id() {
+        let id = ExtendedPoint::identity();
+        assert_eq!(id.compress_decaf(), DecafPoint([0u8; 32]));
+    }
+
+    #[test]
+    fn test_decaf_basepoint_roundtrip() {
+        // XXX fix up this test
+        let bp = BASE_CMPRSSD.decompress().unwrap();
+        let bp_decaf = bp.compress_decaf();
+        let bp_recaf = bp_decaf.decompress().unwrap();
+        let diff = &bp - &bp_recaf;
+        let diff2 = diff.double();
+        let diff4 = diff2.double();
+        //println!("bp {:?}",       bp);
+        //println!("bp_decaf {:?}", bp_decaf);
+        //println!("bp_recaf {:?}", bp_recaf);
+        //println!("diff {:?}", diff.compress());
+        //println!("diff2 {:?}", diff2.compress());
+        //println!("diff4 {:?}", diff4.compress());
+        assert_eq!(diff4.compress(), ExtendedPoint::identity().compress());
+    }
+
+    #[test]
+    fn test_decaf_four_torsion_basepoint() {
+        //println!("");
+        let bp = BASE_CMPRSSD.decompress().unwrap();
+        let bp_decaf = bp.compress_decaf();
+        //println!("orig, {:?}", bp.compress_decaf());
+        for i in (0..8).filter(|x| x % 2 == 0) {
+            let Q = &bp + &constants::EIGHT_TORSION[i];
+            //println!("{}, {:?}", i, Q.compress_decaf());
+            assert_eq!(Q.compress_decaf(), bp_decaf);
+        }
+    }
+
+    #[test]
+    fn test_decaf_four_torsion_random() {
+        //println!("");
+        let mut rng = OsRng::new().unwrap();
+        let s = Scalar::random(&mut rng);
+        let P = ExtendedPoint::basepoint_mult(&s);
+        let P_decaf = P.compress_decaf();
+        //println!("orig, {:?}", P.compress_decaf());
+        for i in (0..8).filter(|x| x % 2 == 0) {
+            let Q = &P + &constants::EIGHT_TORSION[i];
+            //println!("{}, {:?}", i, Q.compress_decaf());
+            assert_eq!(Q.compress_decaf(), P_decaf);
+        }
     }
 
     #[bench]

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -174,12 +174,16 @@ impl CompressedEdwardsY {
 
 /// An `ExtendedPoint` is a point on the curve in 𝗣³(𝔽ₚ).
 /// A point (x,y) in the affine model corresponds to (x:y:1:xy).
+// XXX members should not be public, but that's needed for the
+// constants module. Fix when RFC #1422 lands:
+// https://github.com/rust-lang/rust/issues/32409
 #[derive(Copy, Clone)]
+#[allow(missing_docs)]
 pub struct ExtendedPoint {
-    X: FieldElement,
-    Y: FieldElement,
-    Z: FieldElement,
-    T: FieldElement,
+    pub X: FieldElement,
+    pub Y: FieldElement,
+    pub Z: FieldElement,
+    pub T: FieldElement,
 }
 
 /// A `ProjectivePoint` is a point on the curve in 𝗣²(𝔽ₚ).

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -169,48 +169,6 @@ impl CompressedEdwardsY {
     }
 }
 
-/// A point serialized using Mike Hamburg's Decaf scheme.
-///
-/// XXX think about how this API should work
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct DecafPoint(pub [u8; 32]);
-
-impl DecafPoint {
-    /// View this `DecafPoint` as an array of bytes.
-    pub fn to_bytes(&self) -> [u8;32] {
-        self.0
-    }
-
-    /// Attempt to decompress to an `ExtendedPoint`.
-    pub fn decompress(&self) -> Option<ExtendedPoint> {
-        // XXX should decoding be CT ?
-        // XXX should reject unless s = |s|
-        // XXX need to check that xy is nonnegative and reject otherwise
-        let s = FieldElement::from_bytes(&self.0);
-        let ss = s.square();
-        let X = &s + &s;                    // X = 2s
-        let Z = &FieldElement::one() - &ss; // Z = 1+as^2
-        let u = &(&Z * &Z) - &(&constants::d4 * &ss); // u = Z^2 - 4ds^2
-        let uss = &u * &ss;
-        let mut v = match uss.invsqrt() {
-            Some(v) => v,
-            None => return None,
-        };
-        // Now v = 1/sqrt(us^2) if us^2 is a nonzero square, 0 if us^2 is zero.
-        let uv = &v * &u;
-        if uv.is_negative_decaf() == 1u8 {
-            v.negate();
-        }
-        let mut two_minus_Z = -&Z; two_minus_Z[0] += 2;
-        let mut w = &v * &(&s * &two_minus_Z);
-        w.conditional_assign(&FieldElement::one(), s.is_zero());
-        let Y = &w * &Z;
-        let T = &w * &X;
-
-        Some(ExtendedPoint{ X: X, Y: Y, Z: Z, T: T })
-    }
-}
-
 // ------------------------------------------------------------------------
 // Internal point representations
 // ------------------------------------------------------------------------
@@ -466,75 +424,6 @@ impl ExtendedPoint {
     /// Compress this point to `CompressedEdwardsY` format
     pub fn compress(&self) -> CompressedEdwardsY {
         self.to_projective().compress()
-    }
-
-    /// Compress in Decaf format.
-    pub fn compress_decaf(&self) -> DecafPoint {
-        // Q: Do we want to encode twisted or untwisted?
-        //
-        // Notes: 
-        // Recall that the twisted Edwards curve E_{a,d} is of the form
-        //
-        //     ax^2 + y^2 = 1 + dx^2y^2. 
-        //
-        // Internally, we operate on the curve with a = -1, d =
-        // -121665/121666, a.k.a., the twist.  But maybe we would like
-        // to use Decaf on the untwisted curve with a = 1, d =
-        // 121665/121666.  (why? interop?)
-        //
-        // Fix i, a square root of -1 (mod p).
-        //
-        // The map x -> ix is an isomorphism from E_{a,d} to E_{-a,-d}. 
-        // Its inverse is x -> -ix.
-        // let untwisted_X = &self.X * &constants::MSQRT_M1;
-        // etc.
-
-        // Step 0: pre-rotation, needed for Decaf with E[8] = Z/8
-
-        let mut X = self.X;
-        let mut Y = self.Y;
-        let mut XY = self.T;
-
-        // If y nonzero and xy nonnegative, continue.
-        // Otherwise, add Q_6 = (i,0) = constants::EIGHT_TORSION[6]
-        // (x,y) + Q_6 = (iy,ix)
-        // (X:Y:Z:T) + Q_6 = (iY:iX:Z:-T)
-
-        // XXX it should be possible to avoid this inversion, but
-        // let's make sure the code is correct first
-        let xy = &XY * &self.Z.invert();
-        let is_neg_mask = 1u8 & !(Y.is_nonzero() & xy.is_nonnegative_decaf());
-        let iX = &X * &constants::SQRT_M1;
-        let iY = &Y * &constants::SQRT_M1;
-        X.conditional_assign(&iY, is_neg_mask);
-        Y.conditional_assign(&iX, is_neg_mask);
-        let minus_XY = -&XY;
-        XY.conditional_assign(&minus_XY, is_neg_mask);
-
-        // Step 1: Compute r = 1/sqrt((a-d)(Z+Y)(Z-Y))
-        let Z_plus_Y  = &self.Z + &Y;
-        let Z_minus_Y = &self.Z - &Y;
-        let t = &constants::a_minus_d * &(&Z_plus_Y * &Z_minus_Y);
-        // t should always be square (why?)
-        // XXX is it safe to use option types here?
-        let mut r = t.invsqrt().unwrap();
-
-        // Step 2: Compute u = (a-d)r
-        let u = &constants::a_minus_d * &r;
-
-        // Step 3: Negate r if -2uZ is negative.
-        let uZ = &u * &self.Z;
-        let minus_r = -&r;
-        let m2uZ = -&(&uZ + &uZ);
-        let mask = m2uZ.is_negative_decaf();
-        r.conditional_assign(&minus_r, mask);
-
-        // Step 4: Compute s = |u(r(aZX - dYT)+Y)/a|
-        let minus_ZX = -&(&self.Z * &X);
-        let dYT = &constants::d * &(&Y * &XY);
-        let mut s = &u * &(&(&r * &(&minus_ZX - &dYT)) + &Y);
-        s.negate();
-        DecafPoint(s.abs_decaf().to_bytes())
     }
 
     /// Dehomogenize to a PreComputedPoint.
@@ -968,12 +857,6 @@ impl ExtendedPoint {
 // Debug traits
 // ------------------------------------------------------------------------
 
-impl Debug for DecafPoint {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "DecafPoint: {:?}", &self.0[..])
-    }
-}
-
 impl Debug for ExtendedPoint {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "ExtendedPoint(\n\tX: {:?},\n\tY: {:?},\n\tZ: {:?},\n\tT: {:?}\n)",
@@ -1280,67 +1163,6 @@ mod test {
     #[test]
     fn test_is_identity() {
         assert!(ExtendedPoint::identity().is_identity());
-    }
-
-    #[test]
-    fn test_decaf_decompress_id() {
-        let compressed_id = DecafPoint([0u8; 32]);
-        let id = compressed_id.decompress().unwrap();
-        // This should compress (as ed25519) to the following:
-        let mut bytes = [0u8; 32]; bytes[0] = 1;
-        assert_eq!(id.compress(), CompressedEdwardsY(bytes));
-    }
-
-    #[test]
-    fn test_decaf_compress_id() {
-        let id = ExtendedPoint::identity();
-        assert_eq!(id.compress_decaf(), DecafPoint([0u8; 32]));
-    }
-
-    #[test]
-    fn test_decaf_basepoint_roundtrip() {
-        // XXX fix up this test
-        let bp = BASE_CMPRSSD.decompress().unwrap();
-        let bp_decaf = bp.compress_decaf();
-        let bp_recaf = bp_decaf.decompress().unwrap();
-        let diff = &bp - &bp_recaf;
-        let diff2 = diff.double();
-        let diff4 = diff2.double();
-        //println!("bp {:?}",       bp);
-        //println!("bp_decaf {:?}", bp_decaf);
-        //println!("bp_recaf {:?}", bp_recaf);
-        //println!("diff {:?}", diff.compress());
-        //println!("diff2 {:?}", diff2.compress());
-        //println!("diff4 {:?}", diff4.compress());
-        assert_eq!(diff4.compress(), ExtendedPoint::identity().compress());
-    }
-
-    #[test]
-    fn test_decaf_four_torsion_basepoint() {
-        //println!("");
-        let bp = BASE_CMPRSSD.decompress().unwrap();
-        let bp_decaf = bp.compress_decaf();
-        //println!("orig, {:?}", bp.compress_decaf());
-        for i in (0..8).filter(|x| x % 2 == 0) {
-            let Q = &bp + &constants::EIGHT_TORSION[i];
-            //println!("{}, {:?}", i, Q.compress_decaf());
-            assert_eq!(Q.compress_decaf(), bp_decaf);
-        }
-    }
-
-    #[test]
-    fn test_decaf_four_torsion_random() {
-        //println!("");
-        let mut rng = OsRng::new().unwrap();
-        let s = Scalar::random(&mut rng);
-        let P = ExtendedPoint::basepoint_mult(&s);
-        let P_decaf = P.compress_decaf();
-        //println!("orig, {:?}", P.compress_decaf());
-        for i in (0..8).filter(|x| x % 2 == 0) {
-            let Q = &P + &constants::EIGHT_TORSION[i];
-            //println!("{}, {:?}", i, Q.compress_decaf());
-            assert_eq!(Q.compress_decaf(), P_decaf);
-        }
     }
 
     #[bench]

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -159,7 +159,7 @@ impl CompressedEdwardsY {
             X *= &constants::SQRT_M1;
         }
 
-        if X.is_negative() != (self[31] >> 7) as i32 {
+        if X.is_negative_ed25519() != (self[31] >> 7) as i32 {
             X = X.neg();
         }
         T = &X * &Y;
@@ -391,7 +391,7 @@ impl ProjectivePoint {
         let mut s: [u8; 32];
 
         s      =  y.to_bytes();
-        s[31] ^= (x.is_negative() << 7) as u8;
+        s[31] ^= (x.is_negative_ed25519() << 7) as u8;
         CompressedEdwardsY(s)
     }
 }

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -28,6 +28,9 @@ use subtle::CTAssignable;
 use core::ops::{Add, Sub, Neg};
 
 use curve::ExtendedPoint;
+use curve::BasepointMult;
+use curve::ScalarMult;
+use scalar::Scalar;
 
 // ------------------------------------------------------------------------
 // Compressed points
@@ -178,6 +181,22 @@ impl<'a> Neg for &'a DecafPoint {
 
     fn neg(self) -> DecafPoint {
         DecafPoint(-&self.0)
+    }
+}
+
+impl ScalarMult<Scalar> for DecafPoint {
+    fn scalar_mult(&self, scalar: &Scalar) -> DecafPoint {
+        DecafPoint(self.0.scalar_mult(scalar))
+    }
+}
+
+impl BasepointMult<Scalar> for DecafPoint {
+    fn basepoint() -> DecafPoint {
+        DecafPoint(constants::BASEPOINT)
+    }
+
+    fn basepoint_mult(scalar: &Scalar) -> DecafPoint {
+        DecafPoint(ExtendedPoint::basepoint_mult(scalar))
     }
 }
 

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -361,3 +361,29 @@ mod test {
         }
     }
 }
+
+#[cfg(test)]
+mod bench {
+    use rand::OsRng;
+    use test::Bencher;
+
+    use super::*;
+
+    #[bench]
+    fn decompression(b: &mut Bencher) {
+        let mut rng = OsRng::new().unwrap();
+        let s = Scalar::random(&mut rng);
+        let P = DecafPoint::basepoint_mult(&s);
+        let P_compressed = P.compress();
+        b.iter(|| P_compressed.decompress().unwrap());
+    }
+
+    #[bench]
+    fn compression(b: &mut Bencher) {
+        let mut rng = OsRng::new().unwrap();
+        let s = Scalar::random(&mut rng);
+        let P = DecafPoint::basepoint_mult(&s);
+        b.iter(|| P.compress());
+    }
+}
+

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -83,7 +83,16 @@ impl CompressedDecaf {
         let Y = &w * &Z;
         let T = &w * &X;
 
-        Some(DecafPoint(ExtendedPoint{ X: X, Y: Y, Z: Z, T: T }))
+        // "To decode the point, one must decode it to affine form
+        // instead of projective, and check that xy is non-negative."
+        //
+        // XXX can we merge this inversion with the one above?
+        let xy = &T * &Z.invert();
+        if (Y.is_nonzero() & xy.is_nonnegative_decaf()) == 1u8 {
+            Some(DecafPoint(ExtendedPoint{ X: X, Y: Y, Z: Z, T: T }))
+        } else {
+            None
+        }
     }
 }
 

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -104,7 +104,7 @@ impl DecafPoint {
 
         let mut X = self.0.X;
         let mut Y = self.0.Y;
-        let mut XY = self.0.T;
+        let mut T = self.0.T;
 
         // If y nonzero and xy nonnegative, continue.
         // Otherwise, add Q_6 = (i,0) = constants::EIGHT_TORSION[6]
@@ -113,14 +113,14 @@ impl DecafPoint {
 
         // XXX it should be possible to avoid this inversion, but
         // let's make sure the code is correct first
-        let xy = &XY * &self.0.Z.invert();
+        let xy = &T * &self.0.Z.invert();
         let is_neg_mask = 1u8 & !(Y.is_nonzero() & xy.is_nonnegative_decaf());
         let iX = &X * &constants::SQRT_M1;
         let iY = &Y * &constants::SQRT_M1;
         X.conditional_assign(&iY, is_neg_mask);
         Y.conditional_assign(&iX, is_neg_mask);
-        let minus_XY = -&XY;
-        XY.conditional_assign(&minus_XY, is_neg_mask);
+        let minus_T = -&T;
+        T.conditional_assign(&minus_T, is_neg_mask);
 
         // Step 1: Compute r = 1/sqrt((a-d)(Z+Y)(Z-Y))
         let Z_plus_Y  = &self.0.Z + &Y;
@@ -142,7 +142,7 @@ impl DecafPoint {
 
         // Step 4: Compute s = |u(r(aZX - dYT)+Y)/a|
         let minus_ZX = -&(&self.0.Z * &X);
-        let dYT = &constants::d * &(&Y * &XY);
+        let dYT = &constants::d * &(&Y * &T);
         let mut s = &u * &(&(&r * &(&minus_ZX - &dYT)) + &Y);
         s.negate();
         CompressedDecaf(s.abs_decaf().to_bytes())

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -1,0 +1,234 @@
+// -*- mode: rust; -*-
+//
+// To the extent possible under law, the authors have waived all copyright and
+// related or neighboring rights to curve25519-dalek, using the Creative
+// Commons "CC0" public domain dedication.  See
+// <http://creativecommons.org/publicdomain/zero/.0/> for full details.
+//
+// Authors:
+// - Isis Agora Lovecruft <isis@patternsinthevoid.net>
+// - Henry de Valence <hdevalence@hdevalence.ca>
+
+//! An implementation of Mike Hamburg's Decaf point-compression scheme,
+//! providing a prime-order group.
+
+// We allow non snake_case names because coordinates in projective space are
+// traditionally denoted by the capitalisation of their respective
+// counterparts in affine space.  Yeah, you heard me, rustc, I'm gonna have my
+// affine and projective cakes and eat both of them too.
+#![allow(non_snake_case)]
+
+use core::fmt::Debug;
+
+use constants;
+use field::FieldElement;
+use subtle::CTAssignable;
+
+use curve::ExtendedPoint;
+
+// ------------------------------------------------------------------------
+// Compressed points
+// ------------------------------------------------------------------------
+
+/// A point serialized using Mike Hamburg's Decaf scheme.
+///
+/// XXX think about how this API should work
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct DecafPoint(pub [u8; 32]);
+
+impl DecafPoint {
+    /// View this `DecafPoint` as an array of bytes.
+    pub fn to_bytes(&self) -> [u8;32] {
+        self.0
+    }
+
+    /// Attempt to decompress to an `ExtendedPoint`.
+    pub fn decompress(&self) -> Option<ExtendedPoint> {
+        // XXX should decoding be CT ?
+        // XXX should reject unless s = |s|
+        // XXX need to check that xy is nonnegative and reject otherwise
+        let s = FieldElement::from_bytes(&self.0);
+        let ss = s.square();
+        let X = &s + &s;                    // X = 2s
+        let Z = &FieldElement::one() - &ss; // Z = 1+as^2
+        let u = &(&Z * &Z) - &(&constants::d4 * &ss); // u = Z^2 - 4ds^2
+        let uss = &u * &ss;
+        let mut v = match uss.invsqrt() {
+            Some(v) => v,
+            None => return None,
+        };
+        // Now v = 1/sqrt(us^2) if us^2 is a nonzero square, 0 if us^2 is zero.
+        let uv = &v * &u;
+        if uv.is_negative_decaf() == 1u8 {
+            v.negate();
+        }
+        let mut two_minus_Z = -&Z; two_minus_Z[0] += 2;
+        let mut w = &v * &(&s * &two_minus_Z);
+        w.conditional_assign(&FieldElement::one(), s.is_zero());
+        let Y = &w * &Z;
+        let T = &w * &X;
+
+        Some(ExtendedPoint{ X: X, Y: Y, Z: Z, T: T })
+    }
+}
+
+impl ExtendedPoint {
+    /// Compress in Decaf format.
+    pub fn compress_decaf(&self) -> DecafPoint {
+        // Q: Do we want to encode twisted or untwisted?
+        //
+        // Notes: 
+        // Recall that the twisted Edwards curve E_{a,d} is of the form
+        //
+        //     ax^2 + y^2 = 1 + dx^2y^2. 
+        //
+        // Internally, we operate on the curve with a = -1, d =
+        // -121665/121666, a.k.a., the twist.  But maybe we would like
+        // to use Decaf on the untwisted curve with a = 1, d =
+        // 121665/121666.  (why? interop?)
+        //
+        // Fix i, a square root of -1 (mod p).
+        //
+        // The map x -> ix is an isomorphism from E_{a,d} to E_{-a,-d}. 
+        // Its inverse is x -> -ix.
+        // let untwisted_X = &self.X * &constants::MSQRT_M1;
+        // etc.
+
+        // Step 0: pre-rotation, needed for Decaf with E[8] = Z/8
+
+        let mut X = self.X;
+        let mut Y = self.Y;
+        let mut XY = self.T;
+
+        // If y nonzero and xy nonnegative, continue.
+        // Otherwise, add Q_6 = (i,0) = constants::EIGHT_TORSION[6]
+        // (x,y) + Q_6 = (iy,ix)
+        // (X:Y:Z:T) + Q_6 = (iY:iX:Z:-T)
+
+        // XXX it should be possible to avoid this inversion, but
+        // let's make sure the code is correct first
+        let xy = &XY * &self.Z.invert();
+        let is_neg_mask = 1u8 & !(Y.is_nonzero() & xy.is_nonnegative_decaf());
+        let iX = &X * &constants::SQRT_M1;
+        let iY = &Y * &constants::SQRT_M1;
+        X.conditional_assign(&iY, is_neg_mask);
+        Y.conditional_assign(&iX, is_neg_mask);
+        let minus_XY = -&XY;
+        XY.conditional_assign(&minus_XY, is_neg_mask);
+
+        // Step 1: Compute r = 1/sqrt((a-d)(Z+Y)(Z-Y))
+        let Z_plus_Y  = &self.Z + &Y;
+        let Z_minus_Y = &self.Z - &Y;
+        let t = &constants::a_minus_d * &(&Z_plus_Y * &Z_minus_Y);
+        // t should always be square (why?)
+        // XXX is it safe to use option types here?
+        let mut r = t.invsqrt().unwrap();
+
+        // Step 2: Compute u = (a-d)r
+        let u = &constants::a_minus_d * &r;
+
+        // Step 3: Negate r if -2uZ is negative.
+        let uZ = &u * &self.Z;
+        let minus_r = -&r;
+        let m2uZ = -&(&uZ + &uZ);
+        let mask = m2uZ.is_negative_decaf();
+        r.conditional_assign(&minus_r, mask);
+
+        // Step 4: Compute s = |u(r(aZX - dYT)+Y)/a|
+        let minus_ZX = -&(&self.Z * &X);
+        let dYT = &constants::d * &(&Y * &XY);
+        let mut s = &u * &(&(&r * &(&minus_ZX - &dYT)) + &Y);
+        s.negate();
+        DecafPoint(s.abs_decaf().to_bytes())
+    }
+}
+
+
+// ------------------------------------------------------------------------
+// Debug traits
+// ------------------------------------------------------------------------
+
+impl Debug for DecafPoint {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        write!(f, "DecafPoint: {:?}", &self.0[..])
+    }
+}
+
+
+// ------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use rand::OsRng;
+
+    use scalar::Scalar;
+    use constants;
+    use constants::BASE_CMPRSSD;
+    use curve::CompressedEdwardsY;
+    use curve::ExtendedPoint;
+    use curve::Identity;
+    use super::*;
+
+    #[test]
+    fn test_decaf_decompress_id() {
+        let compressed_id = DecafPoint([0u8; 32]);
+        let id = compressed_id.decompress().unwrap();
+        // This should compress (as ed25519) to the following:
+        let mut bytes = [0u8; 32]; bytes[0] = 1;
+        assert_eq!(id.compress(), CompressedEdwardsY(bytes));
+    }
+
+    #[test]
+    fn test_decaf_compress_id() {
+        let id = ExtendedPoint::identity();
+        assert_eq!(id.compress_decaf(), DecafPoint([0u8; 32]));
+    }
+
+    #[test]
+    fn test_decaf_basepoint_roundtrip() {
+        // XXX fix up this test
+        let bp = BASE_CMPRSSD.decompress().unwrap();
+        let bp_decaf = bp.compress_decaf();
+        let bp_recaf = bp_decaf.decompress().unwrap();
+        let diff = &bp - &bp_recaf;
+        let diff2 = diff.double();
+        let diff4 = diff2.double();
+        //println!("bp {:?}",       bp);
+        //println!("bp_decaf {:?}", bp_decaf);
+        //println!("bp_recaf {:?}", bp_recaf);
+        //println!("diff {:?}", diff.compress());
+        //println!("diff2 {:?}", diff2.compress());
+        //println!("diff4 {:?}", diff4.compress());
+        assert_eq!(diff4.compress(), ExtendedPoint::identity().compress());
+    }
+
+    #[test]
+    fn test_decaf_four_torsion_basepoint() {
+        //println!("");
+        let bp = BASE_CMPRSSD.decompress().unwrap();
+        let bp_decaf = bp.compress_decaf();
+        //println!("orig, {:?}", bp.compress_decaf());
+        for i in (0..8).filter(|x| x % 2 == 0) {
+            let Q = &bp + &constants::EIGHT_TORSION[i];
+            //println!("{}, {:?}", i, Q.compress_decaf());
+            assert_eq!(Q.compress_decaf(), bp_decaf);
+        }
+    }
+
+    #[test]
+    fn test_decaf_four_torsion_random() {
+        //println!("");
+        let mut rng = OsRng::new().unwrap();
+        let s = Scalar::random(&mut rng);
+        let P = ExtendedPoint::basepoint_mult(&s);
+        let P_decaf = P.compress_decaf();
+        //println!("orig, {:?}", P.compress_decaf());
+        for i in (0..8).filter(|x| x % 2 == 0) {
+            let Q = &P + &constants::EIGHT_TORSION[i];
+            //println!("{}, {:?}", i, Q.compress_decaf());
+            assert_eq!(Q.compress_decaf(), P_decaf);
+        }
+    }
+}

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -154,6 +154,15 @@ impl DecafPoint {
         s.negate();
         CompressedDecaf(s.abs_decaf().to_bytes())
     }
+
+    /// Return the coset self + E[4], for debugging.
+    fn coset4(&self) -> [ExtendedPoint; 4] {
+        [  self.0
+        , &self.0 + &constants::EIGHT_TORSION[2]
+        , &self.0 + &constants::EIGHT_TORSION[4]
+        , &self.0 + &constants::EIGHT_TORSION[6]
+        ]
+    }
 }
 
 // ------------------------------------------------------------------------
@@ -228,7 +237,9 @@ impl Debug for CompressedDecaf {
 
 impl Debug for DecafPoint {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "DecafPoint: {:?}", &self.0)
+        let coset = self.coset4();
+        write!(f, "DecafPoint: coset \n{:?}\n{:?}\n{:?}\n{:?}",
+               coset[0], coset[1], coset[2], coset[3])
     }
 }
 
@@ -277,9 +288,9 @@ mod test {
     #[test]
     fn test_decaf_four_torsion_basepoint() {
         let bp = DecafPoint::basepoint();
-        for i in (0..8).filter(|x| x % 2 == 0) {
-            let Q = &bp + &DecafPoint(constants::EIGHT_TORSION[i]);
-            assert_eq!(Q, bp);
+        let bp_coset = bp.coset4();
+        for i in 0..4 {
+            assert_eq!(bp, DecafPoint(bp_coset[i]));
         }
     }
 
@@ -288,9 +299,9 @@ mod test {
         let mut rng = OsRng::new().unwrap();
         let s = Scalar::random(&mut rng);
         let P = DecafPoint::basepoint_mult(&s);
-        for i in (0..8).filter(|x| x % 2 == 0) {
-            let Q = &P + &DecafPoint(constants::EIGHT_TORSION[i]);
-            assert_eq!(Q, P);
+        let P_coset = P.coset4();
+        for i in 0..4 {
+            assert_eq!(P, DecafPoint(P_coset[i]));
         }
     }
 }

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -25,6 +25,8 @@ use constants;
 use field::FieldElement;
 use subtle::CTAssignable;
 
+use core::ops::{Add, Sub, Neg};
+
 use curve::ExtendedPoint;
 
 // ------------------------------------------------------------------------
@@ -151,6 +153,33 @@ impl DecafPoint {
     }
 }
 
+// ------------------------------------------------------------------------
+// Arithmetic
+// ------------------------------------------------------------------------
+
+impl<'a, 'b> Add<&'b DecafPoint> for &'a DecafPoint {
+    type Output = DecafPoint;
+
+    fn add(self, other: &'b DecafPoint) -> DecafPoint {
+        DecafPoint(&self.0 + &other.0)
+    }
+}
+
+impl<'a, 'b> Sub<&'b DecafPoint> for &'a DecafPoint {
+    type Output = DecafPoint;
+
+    fn sub(self, other: &'b DecafPoint) -> DecafPoint {
+        DecafPoint(&self.0 - &other.0)
+    }
+}
+
+impl<'a> Neg for &'a DecafPoint {
+    type Output = DecafPoint;
+
+    fn neg(self) -> DecafPoint {
+        DecafPoint(-&self.0)
+    }
+}
 
 // ------------------------------------------------------------------------
 // Debug traits

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -266,47 +266,31 @@ mod test {
 
     #[test]
     fn test_decaf_basepoint_roundtrip() {
-        // XXX fix up this test
-        let bp = BASE_CMPRSSD.decompress().unwrap();
-        let bp_decaf = DecafPoint(bp).compress();
-        let bp_recaf = bp_decaf.decompress().unwrap().0;
-        let diff = &bp - &bp_recaf;
-        let diff2 = diff.double();
-        let diff4 = diff2.double();
-        //println!("bp {:?}",       bp);
-        //println!("bp_decaf {:?}", bp_decaf);
-        //println!("bp_recaf {:?}", bp_recaf);
-        //println!("diff {:?}", diff.compress());
-        //println!("diff2 {:?}", diff2.compress());
-        //println!("diff4 {:?}", diff4.compress());
+        let bp_compressed_decaf = DecafPoint::basepoint().compress();
+        let bp_recaf = bp_compressed_decaf.decompress().unwrap().0;
+        // Check that bp_recaf differs from bp by a point of order 4
+        let diff = &ExtendedPoint::basepoint() - &bp_recaf;
+        let diff4 = diff.mult_by_pow_2(4);
         assert_eq!(diff4.compress(), ExtendedPoint::identity().compress());
     }
 
     #[test]
     fn test_decaf_four_torsion_basepoint() {
-        //println!("");
-        let bp = BASE_CMPRSSD.decompress().unwrap();
-        let bp_decaf = DecafPoint(bp).compress();
-        //println!("orig, {:?}", bp.compress());
+        let bp = DecafPoint::basepoint();
         for i in (0..8).filter(|x| x % 2 == 0) {
-            let Q = &bp + &constants::EIGHT_TORSION[i];
-            //println!("{}, {:?}", i, Q.compress());
-            assert_eq!(DecafPoint(Q).compress(), bp_decaf);
+            let Q = &bp + &DecafPoint(constants::EIGHT_TORSION[i]);
+            assert_eq!(Q, bp);
         }
     }
 
     #[test]
     fn test_decaf_four_torsion_random() {
-        //println!("");
         let mut rng = OsRng::new().unwrap();
         let s = Scalar::random(&mut rng);
-        let P = ExtendedPoint::basepoint_mult(&s);
-        let P_decaf = DecafPoint(P).compress();
-        //println!("orig, {:?}", P.compress());
+        let P = DecafPoint::basepoint_mult(&s);
         for i in (0..8).filter(|x| x % 2 == 0) {
-            let Q = &P + &constants::EIGHT_TORSION[i];
-            //println!("{}, {:?}", i, Q.compress());
-            assert_eq!(DecafPoint(Q).compress(), P_decaf);
+            let Q = &P + &DecafPoint(constants::EIGHT_TORSION[i]);
+            assert_eq!(Q, P);
         }
     }
 }

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -9,8 +9,9 @@
 // - Isis Agora Lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
-//! An implementation of Mike Hamburg's Decaf point-compression scheme,
-//! providing a prime-order group.
+//! An implementation of Mike Hamburg's Decaf cofactor-eliminating
+//! point-compression scheme, providing a prime-order group on top of
+//! a non-prime-order elliptic curve.
 
 // We allow non snake_case names because coordinates in projective space are
 // traditionally denoted by the capitalisation of their respective
@@ -36,6 +37,7 @@ use curve::ExtendedPoint;
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct CompressedDecaf(pub [u8; 32]);
 
+/// The result of compressing a `DecafPoint`.
 impl CompressedDecaf {
     /// View this `CompressedDecaf` as an array of bytes.
     pub fn to_bytes(&self) -> [u8;32] {

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -30,6 +30,7 @@ use core::ops::{Add, Sub, Neg};
 use curve::ExtendedPoint;
 use curve::BasepointMult;
 use curve::ScalarMult;
+use curve::Identity;
 use scalar::Scalar;
 
 // ------------------------------------------------------------------------
@@ -76,6 +77,12 @@ impl CompressedDecaf {
         let T = &w * &X;
 
         Some(DecafPoint(ExtendedPoint{ X: X, Y: Y, Z: Z, T: T }))
+    }
+}
+
+impl Identity for CompressedDecaf {
+    fn identity() -> CompressedDecaf {
+        CompressedDecaf([0u8;32])
     }
 }
 
@@ -162,6 +169,12 @@ impl DecafPoint {
         , &self.0 + &constants::EIGHT_TORSION[4]
         , &self.0 + &constants::EIGHT_TORSION[6]
         ]
+    }
+}
+
+impl Identity for DecafPoint {
+    fn identity() -> DecafPoint {
+        DecafPoint(ExtendedPoint::identity())
     }
 }
 
@@ -262,7 +275,7 @@ mod test {
 
     #[test]
     fn test_decaf_decompress_id() {
-        let compressed_id = CompressedDecaf([0u8; 32]);
+        let compressed_id = CompressedDecaf::identity();
         let id = compressed_id.decompress().unwrap();
         // This should compress (as ed25519) to the following:
         let mut bytes = [0u8; 32]; bytes[0] = 1;
@@ -271,8 +284,8 @@ mod test {
 
     #[test]
     fn test_decaf_compress_id() {
-        let id = DecafPoint(ExtendedPoint::identity());
-        assert_eq!(id.compress(), CompressedDecaf([0u8; 32]));
+        let id = DecafPoint::identity();
+        assert_eq!(id.compress(), CompressedDecaf::identity());
     }
 
     #[test]

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -181,6 +181,7 @@ mod test {
     use constants::BASE_CMPRSSD;
     use curve::CompressedEdwardsY;
     use curve::ExtendedPoint;
+    use curve::BasepointMult;
     use curve::Identity;
     use super::*;
 

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -159,15 +159,12 @@ impl DecafPoint {
         r.conditional_negate(m2uZ.is_negative_decaf());
 
         // Step 4: Compute s = | u(r(aZX - dYT)+Y)/a|
-        //                   = |-u(r(aZX - dYT)+Y)|
+        //                   = |u(r(-ZX - dYT)+Y)| since a = -1
         let minus_ZX = -&(&self.0.Z * &X);
         let dYT = &constants::d * &(&Y * &T);
-        // Compute s = u(r(aZX - dYT)+Y)
+        // Compute s = u(r(aZX - dYT)+Y) and cnegate for abs
         let mut s = &u * &(&(&r * &(&minus_ZX - &dYT)) + &Y);
-        // Set s <- |-s|
-        // XXX I think there's a sign error somewhere?
-        // flipping the sign here makes the tests pass
-        let neg = s.is_nonnegative_decaf();
+        let neg = s.is_negative_decaf();
         s.conditional_negate(neg);
         CompressedDecaf(s.to_bytes())
     }

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -12,6 +12,9 @@
 //! An implementation of Mike Hamburg's Decaf cofactor-eliminating
 //! point-compression scheme, providing a prime-order group on top of
 //! a non-prime-order elliptic curve.
+//!
+//! Note: this code is currently feature-gated with the `yolocrypto`
+//! feature flag, because our implementation is still unfinished.
 
 // We allow non snake_case names because coordinates in projective space are
 // traditionally denoted by the capitalisation of their respective

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -34,10 +34,10 @@ use curve::ExtendedPoint;
 ///
 /// XXX think about how this API should work
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct DecafPoint(pub [u8; 32]);
+pub struct CompressedDecaf(pub [u8; 32]);
 
-impl DecafPoint {
-    /// View this `DecafPoint` as an array of bytes.
+impl CompressedDecaf {
+    /// View this `CompressedDecaf` as an array of bytes.
     pub fn to_bytes(&self) -> [u8;32] {
         self.0
     }
@@ -74,7 +74,7 @@ impl DecafPoint {
 
 impl ExtendedPoint {
     /// Compress in Decaf format.
-    pub fn compress_decaf(&self) -> DecafPoint {
+    pub fn compress_decaf(&self) -> CompressedDecaf {
         // Q: Do we want to encode twisted or untwisted?
         //
         // Notes: 
@@ -139,7 +139,7 @@ impl ExtendedPoint {
         let dYT = &constants::d * &(&Y * &XY);
         let mut s = &u * &(&(&r * &(&minus_ZX - &dYT)) + &Y);
         s.negate();
-        DecafPoint(s.abs_decaf().to_bytes())
+        CompressedDecaf(s.abs_decaf().to_bytes())
     }
 }
 
@@ -148,9 +148,9 @@ impl ExtendedPoint {
 // Debug traits
 // ------------------------------------------------------------------------
 
-impl Debug for DecafPoint {
+impl Debug for CompressedDecaf {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "DecafPoint: {:?}", &self.0[..])
+        write!(f, "CompressedDecaf: {:?}", &self.0[..])
     }
 }
 
@@ -173,7 +173,7 @@ mod test {
 
     #[test]
     fn test_decaf_decompress_id() {
-        let compressed_id = DecafPoint([0u8; 32]);
+        let compressed_id = CompressedDecaf([0u8; 32]);
         let id = compressed_id.decompress().unwrap();
         // This should compress (as ed25519) to the following:
         let mut bytes = [0u8; 32]; bytes[0] = 1;
@@ -183,7 +183,7 @@ mod test {
     #[test]
     fn test_decaf_compress_id() {
         let id = ExtendedPoint::identity();
-        assert_eq!(id.compress_decaf(), DecafPoint([0u8; 32]));
+        assert_eq!(id.compress_decaf(), CompressedDecaf([0u8; 32]));
     }
 
     #[test]

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -157,6 +157,22 @@ impl DecafPoint {
 }
 
 // ------------------------------------------------------------------------
+// Equality
+// ------------------------------------------------------------------------
+
+/// XXX check whether there's a simple way to do equality checking
+/// with cofactor 8, not just cofactor 4, and add a CT equality function?
+impl PartialEq for DecafPoint {
+    fn eq(&self, other: &DecafPoint) -> bool {
+        let  self_compressed =  self.compress();
+        let other_compressed = other.compress();
+        self_compressed == other_compressed
+    }
+}
+
+impl Eq for DecafPoint {}
+
+// ------------------------------------------------------------------------
 // Arithmetic
 // ------------------------------------------------------------------------
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -510,13 +510,14 @@ impl FieldElement {
         (!equal_so_far & 1 & greater) as u8
     }
 
-    /// Determine if this `FieldElement` is negative.
+    /// Determine if this `FieldElement` is negative, in the
+    /// sense used in the ed25519 paper.
     ///
     /// # Return
     ///
     /// If negative, return `1i32`.  Otherwise, return `0i32`.
     // XXX should return u8
-    pub fn is_negative(&self) -> i32 { //FeIsNegative
+    pub fn is_negative_ed25519(&self) -> i32 { //FeIsNegative
         let bytes = self.to_bytes();
         (bytes[0] & 1) as i32
     }

--- a/src/field.rs
+++ b/src/field.rs
@@ -522,6 +522,39 @@ impl FieldElement {
         (bytes[0] & 1) as i32
     }
 
+    /// Determine if this `FieldElement` is negative, in the
+    /// sense used by Decaf: `x` is nonnegative if the least
+    /// absolute residue for `x` lies in `[0, (p-1)/2]`, and
+    /// is negative otherwise.
+    ///
+    /// # Return
+    ///
+    /// Returns `1u8` if negative, `0u8` if nonnegative.
+    ///
+    /// # Implementation
+    ///
+    /// Uses a trick borrowed from Mike Hamburg's code.  Let `x \in
+    /// F_p` and let `y \in Z` be the least absolute residue for `x`.
+    /// Suppose `y ≤ (p-1)/2`.  Then `2y < p` so `2y = 2y mod p` and
+    /// `2y mod p` is even.  On the other hand, if `y > (p-1)/2` then
+    /// `2y ≥ p`; since `y < p`, `2y \in [p, 2p)`, so `2y mod p =
+    /// 2y-p`, which is odd.
+    ///
+    /// Thus we can test whether `y ≤ (p-1)/2` by checking whether `2y
+    /// mod p` is even.
+    pub fn is_negative_decaf(&self) -> u8 {
+        let y = self + self;
+        (y.to_bytes()[0] & 1) as u8
+    }
+
+    /// Determine if this `FieldElement` is nonnegative, in the
+    /// sense used by Decaf: `x` is nonnegative if the least
+    /// absolute residue for `x` lies in `[0, (p-1)/2]`, and
+    /// is negative otherwise.
+    pub fn is_nonnegative_decaf(&self) -> u8 {
+        1u8 & (!self.is_negative_decaf())
+    }
+
     /// Determine if this `FieldElement` is zero.
     ///
     /// # Return

--- a/src/field.rs
+++ b/src/field.rs
@@ -521,6 +521,15 @@ impl FieldElement {
         (bytes[0] & 1) as i32
     }
 
+    /// Determine if this `FieldElement` is zero.
+    ///
+    /// # Return
+    ///
+    /// If zero, return `1u8`.  Otherwise, return `0u8`.
+    pub fn is_zero(&self) -> u8 {
+        return 1u8 & (!self.is_nonzero());
+    }
+
     /// Determine if this `FieldElement` is non-zero.
     ///
     /// # Return

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,9 @@ extern crate rand;
 // Modules for low-level operations directly on field elements and curve points.
 
 pub mod field;
-pub mod curve;
 pub mod scalar;
+pub mod curve;
+pub mod decaf;
 
 // Constant-time functions and other miscelaneous utilities.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,9 @@ extern crate rand;
 pub mod field;
 pub mod scalar;
 pub mod curve;
+
+// Feature gate decaf while our implementation is unfinished and probably incorrect.
+#[cfg(feature = "yolocrypto")]
 pub mod decaf;
 
 // Constant-time functions and other miscelaneous utilities.


### PR DESCRIPTION
This branch has a very WIP, first-draft implementation of Decaf for Curve25519.  It's probably full of errors, so it's feature-gated with the `yolocrypto` flag.

Merging it now instead of later means:
* It's easy to keep it in sync with changes to the rest of the tree;
* We can start thinking about how to use its API in other protocols, even if the implementation is incomplete.