### PR TITLE
Hash to scalar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,16 @@ version = "0.3.3"
 optional = true
 version = "0.3"
 
+[dependencies.digest]
+version = "0.4"
+
+[dependencies.generic-array]
+# same version that digest depends on
+version = "^0.6"
+
+[dev-dependencies.sha2]
+version = "0.4"
+
 [features]
 default = ["std"]
 std = ["rand"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,9 +38,14 @@ extern crate std;
 
 #[cfg(test)]
 extern crate test;
+#[cfg(test)]
+extern crate sha2;
 
 #[macro_use]
 extern crate arrayref;
+
+extern crate generic_array;
+extern crate digest;
 
 #[cfg(feature = "std")]
 extern crate rand;

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -176,6 +176,8 @@ impl Scalar {
     /// extern crate sha2;
     /// use sha2::Sha512;
     ///
+    /// # // Need fn main() here in comment so the doctest compiles
+    /// # // See https://doc.rust-lang.org/book/documentation.html#documentation-as-tests
     /// # fn main() {
     /// let msg = "To really appreciate architecture, you may even need to commit a murder";
     /// let s = Scalar::hash_from_bytes::<Sha512>(msg.as_bytes());


### PR DESCRIPTION
Add a generic hash-to-scalar function, parameterized by a `Digest` instance with 512 bits of output.