### PR TITLE
Added conditional compilation for 'test' feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 
 #![no_std]
 #![allow(unused_features)]
-#![feature(test)]
+#![cfg_attr(test, feature(test))]
 #![deny(missing_docs)] // refuse to compile if documentation is missing
 
 //! # curve25519-dalek


### PR DESCRIPTION
The crate won't currently compile on stable unless this is added.