### PR TITLE
Generic basepoint precomputations.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,12 @@ version = "^0.6"
 version = "0.4"
 
 [features]
+nightly = ["basepoint_table_creation"]
 default = ["std"]
 std = ["rand"]
 yolocrypto = []
+# Needs nightly for placement new
+basepoint_table_creation = []
 
 # The development profile, used for `cargo build`.
 [profile.dev]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -23,7 +23,7 @@ use field::FieldElement;
 use curve::ExtendedPoint;
 use curve::AffineNielsPoint;
 use curve::CompressedEdwardsY;
-use curve::BasepointTable;
+use curve::EdwardsBasepointTable;
 use scalar::Scalar;
 
 pub const d: FieldElement       = FieldElement([
@@ -226,7 +226,7 @@ pub const bi: [AffineNielsPoint; 8] = [
 ///
 /// The table is defined so `constants::base[i][j-1] = j*(16^2i)*B`,
 /// for `0 ≤ i < 32`, `1 ≤ j < 9`.
-pub const ED25519_BASEPOINT_TABLE: BasepointTable = BasepointTable([
+pub const ED25519_BASEPOINT_TABLE: EdwardsBasepointTable = EdwardsBasepointTable([
 [
     AffineNielsPoint{
         y_plus_x:  FieldElement([25967493, -14356035, 29566456, 3660896, -12694345, 4014787, 27544626, -11754271, -6079156, 2047605]),

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -23,6 +23,7 @@ use field::FieldElement;
 use curve::ExtendedPoint;
 use curve::AffineNielsPoint;
 use curve::CompressedEdwardsY;
+use curve::BasepointTable;
 use scalar::Scalar;
 
 pub const d: FieldElement       = FieldElement([
@@ -100,7 +101,7 @@ pub const BASE_CMPRSSD: CompressedEdwardsY =
                         0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66]);
 
 /// Basepoint has y = 4/5.
-pub const BASEPOINT: ExtendedPoint = ExtendedPoint{
+pub const ED25519_BASEPOINT: ExtendedPoint = ExtendedPoint{
         X: FieldElement([-14297830, -7645148, 16144683, -16471763, 27570974, -2696100, -26142465, 8378389, 20764389, 8758491]),
         Y: FieldElement([-26843541, -6710886, 13421773, -13421773, 26843546, 6710886, -13421773, 13421773, -26843546, -6710886]),
         Z: FieldElement([1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
@@ -225,7 +226,7 @@ pub const bi: [AffineNielsPoint; 8] = [
 ///
 /// The table is defined so `constants::base[i][j-1] = j*(16^2i)*B`,
 /// for `0 ≤ i < 32`, `1 ≤ j < 9`.
-pub const base: [[AffineNielsPoint; 8]; 32] = [
+pub const ED25519_BASEPOINT_TABLE: BasepointTable = BasepointTable([
 [
     AffineNielsPoint{
         y_plus_x:  FieldElement([25967493, -14356035, 29566456, 3660896, -12694345, 4014787, 27544626, -11754271, -6079156, 2047605]),
@@ -1569,7 +1570,7 @@ pub const base: [[AffineNielsPoint; 8]; 32] = [
         y_minus_x: FieldElement([29701166, -14373934, -10878120, 9279288, -17568, 13127210, 21382910, 11042292, 25838796, 4642684]),
         xy2d:      FieldElement([-20430234, 14955537, -24126347, 8124619, -5369288, -5990470, 30468147, -13900640, 18423289, 4177476]),
     },
-]];
+]]);
 
 #[cfg(test)]
 mod test {
@@ -1669,24 +1670,5 @@ mod test {
         let a = FieldElement([-1,0,0,0,0,0,0,0,0,0]);
         let a_minus_d = &a - &constants::d;
         assert_eq!(a_minus_d, constants::a_minus_d);
-    }
-
-    /// Test the values in the lookup table of precomputed multiples
-    /// of the basepoint.
-    #[test]
-    fn test_precomputed_basepoint_multiples() {
-        let bp  =  constants::BASE_CMPRSSD.decompress().unwrap();
-        let mut P = bp;
-        for i in 0..32 {
-            // P = (16^2)^i * B
-            let mut jP = P.to_affine_niels();
-            for j in 1..9 {
-                // constants::base[i][j-1] is supposed to be
-                // j * (16^2)^i * B
-                assert_eq!(constants::base[i][j-1], jP);
-                jP = (&P + &jP).to_extended().to_affine_niels();
-            }
-            P = P.mult_by_pow_2(8);
-        }
     }
 }

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -1270,6 +1270,13 @@ mod test {
         assert_eq!(aB.compress_edwards(), A_TIMES_BASEPOINT);
     }
 
+    /// Test that multiplication by the basepoint order kills the basepoint
+    #[test]
+    fn basepoint_mult_by_basepoint_order() {
+        let should_be_id = ExtendedPoint::basepoint_mult(&constants::l);
+        assert!(should_be_id.is_identity());
+    }
+
     /// Test scalar_mult versus a known scalar multiple from ed25519.py
     #[test]
     fn scalar_mult_vs_ed25519py() {

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -834,13 +834,7 @@ impl BasepointTable {
     pub fn create(basepoint: &ExtendedPoint) -> Box<BasepointTable> {
         // Create the table storage
         // XXX this is a dirty hack, does placement new work here?
-        let mut table: Box<[[AffineNielsPoint; 8]; 32]> = unsafe {
-            Box::from_raw(
-                Box::into_raw(             // 8 * 32 = 256
-                    vec![AffineNielsPoint::identity(); 256].into_boxed_slice()
-                ) as *mut [[AffineNielsPoint; 8]; 32]
-            )
-        };
+        let mut table = box [[AffineNielsPoint::identity(); 8]; 32];
         let mut P = basepoint.clone();
         for i in 0..32 {
             // P = (16^2)^i * B

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -1486,4 +1486,10 @@ mod bench {
 
         b.iter(|| p1.mult_by_cofactor() );
     }
+
+    #[bench]
+    fn create_basepoint_table(b: &mut Bencher) {
+        let aB = ExtendedPoint::basepoint_mult(&A_SCALAR);
+        b.iter(|| BasepointTable::create(&aB));
+    }
 }

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -81,9 +81,6 @@ use core::fmt::Debug;
 use core::iter::Iterator;
 use core::ops::{Add, Sub, Neg};
 
-#[cfg(feature = "std")]
-use std::boxed::Box;
-
 use constants;
 use field::FieldElement;
 use scalar::Scalar;
@@ -95,6 +92,8 @@ use subtle::CTNegatable;
 
 #[cfg(not(feature = "std"))]
 use collections::boxed::Box;
+#[cfg(feature = "std")]
+use std::boxed::Box;
 
 // ------------------------------------------------------------------------
 // Compressed points
@@ -831,6 +830,7 @@ pub struct EdwardsBasepointTable(pub [[AffineNielsPoint; 8]; 32]);
 
 impl EdwardsBasepointTable {
     /// Create a table of precomputed multiples of `basepoint`.
+    #[cfg(feature="basepoint_table_creation")]
     pub fn create(basepoint: &ExtendedPoint) -> Box<EdwardsBasepointTable> {
         // Create the table storage
         // XXX can we be assured that this is not allocated on the stack?
@@ -1312,6 +1312,7 @@ mod test {
 
     /// Test precomputed basepoint mult
     #[test]
+    #[cfg(feature="basepoint_table_creation")]
     fn test_precomputed_basepoint_mult() {
         let table = EdwardsBasepointTable::create(&constants::ED25519_BASEPOINT);
         let aB_1 = ExtendedPoint::basepoint_mult(&A_SCALAR);
@@ -1487,6 +1488,7 @@ mod bench {
         b.iter(|| p1.mult_by_cofactor() );
     }
 
+    #[cfg(feature="basepoint_table_creation")]
     #[bench]
     fn create_basepoint_table(b: &mut Bencher) {
         let aB = ExtendedPoint::basepoint_mult(&A_SCALAR);

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -875,7 +875,7 @@ impl EdwardsBasepointTable {
     /// We then use the `select_precomputed_point` function, which
     /// takes `-8 ≤ x < 8` and `[16^2i * B, ..., 8 * 16^2i * B]`,
     /// and returns `x * 16^2i * B` in constant time.
-    fn basepoint_mult(&self, scalar: &Scalar) -> ExtendedPoint { //GeScalarMultBase
+    pub fn basepoint_mult(&self, scalar: &Scalar) -> ExtendedPoint {
         let e = scalar.to_radix_16();
         let mut h = ExtendedPoint::identity();
         let mut t: CompletedPoint;

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -253,7 +253,7 @@ impl BasepointMult<Scalar> for DecafPoint {
     // XXX is this actually in the image of the isogeny,
     // or do we need a different basepoint?
     fn basepoint() -> DecafPoint {
-        DecafPoint(constants::BASEPOINT)
+        DecafPoint(ExtendedPoint::basepoint())
     }
 
     fn basepoint_mult(scalar: &Scalar) -> DecafPoint {
@@ -322,7 +322,7 @@ mod test {
         // Check that bp_recaf differs from bp by a point of order 4
         let diff = &ExtendedPoint::basepoint() - &bp_recaf;
         let diff4 = diff.mult_by_pow_2(4);
-        assert_eq!(diff4.compress_edwards(), ExtendedPoint::identity().compress_edwards());
+        assert_eq!(diff4.compress_edwards(), CompressedEdwardsY::identity());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(collections))]
+#![cfg_attr(feature = "nightly", feature(box_syntax))]
 #![allow(unused_features)]
 #![feature(test)]
-#![feature(box_syntax)]
 #![deny(missing_docs)] // refuse to compile if documentation is missing
 
 //! # curve25519-dalek

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(not(feature = "std"), feature(collections))]
 #![allow(unused_features)]
 #![feature(test)]
+#![feature(box_syntax)]
 #![deny(missing_docs)] // refuse to compile if documentation is missing
 
 //! # curve25519-dalek


### PR DESCRIPTION
This is feature-gated on nightly because I'm not feeling good about stack-allocating a 30K table.  Maybe it's not a big deal, in which case we can just throw away the `box`es.