### PR TITLE
Make benchmarks and #[feature(test)] dependent on feature bench

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ rust:
   - nightly
 
 env:
-  - TEST_COMMAND=test
-  - TEST_COMMAND=bench
+  - TEST_COMMAND=test FEATURES='yolocrypto'
+  - TEST_COMMAND=bench FEATURES='yolocrypto bench'
 
 matrix:
   # We can probably remove this, as we reasonably expect dalek to work on
@@ -16,7 +16,9 @@ matrix:
   # https://github.com/isislovecruft/curve25519-dalek/pull/38#issuecomment-286027562
   allow_failures:
     - rust: stable
+      env: TEST_COMMAND=bench FEATURES='yolocrypto bench'
     - rust: beta
+      env: TEST_COMMAND=bench FEATURES='yolocrypto bench'
 
 script:
-  - cargo $TEST_COMMAND --features "yolocrypto"
+  - cargo $TEST_COMMAND --features="$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ version = "0.4"
 default = ["std"]
 std = ["rand"]
 yolocrypto = []
+bench = []
 
 # The development profile, used for `cargo build`.
 [profile.dev]

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -1354,7 +1354,7 @@ mod test {
 // Benchmarks
 // ------------------------------------------------------------------------
 
-#[cfg(test)]
+#[cfg(all(test, feature = "bench"))]
 mod bench {
     use test::Bencher;
     use constants;

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -358,7 +358,7 @@ mod test {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "bench"))]
 mod bench {
     use rand::OsRng;
     use test::Bencher;

--- a/src/field.rs
+++ b/src/field.rs
@@ -921,31 +921,12 @@ impl FieldElement {
 #[cfg(test)]
 mod test {
     use field::*;
-    use test::Bencher;
     use subtle::CTNegatable;
-
-    #[bench]
-    fn bench_fieldelement_a_mul_a(b: &mut Bencher) {
-        let a = FieldElement::from_bytes(&A_BYTES);
-        b.iter(|| &a*&a);
-    }
-
-    #[bench]
-    fn bench_fieldelement_a_sq(b: &mut Bencher) {
-        let a = FieldElement::from_bytes(&A_BYTES);
-        b.iter(|| a.square());
-    }
-
-    #[bench]
-    fn bench_fieldelement_a_inv(b: &mut Bencher) {
-        let a = FieldElement::from_bytes(&A_BYTES);
-        b.iter(|| a.invert());
-    }
 
     /// Random element a of GF(2^255-19), from Sage
     /// a = 1070314506888354081329385823235218444233221\
     ///     2228051251926706380353716438957572
-    static A_BYTES: [u8;32] =
+    pub static A_BYTES: [u8;32] =
         [ 0x04, 0xfe, 0xdf, 0x98, 0xa7, 0xfa, 0x0a, 0x68,
           0x84, 0x92, 0xbd, 0x59, 0x08, 0x07, 0xa7, 0x03,
           0x9e, 0xd1, 0xf6, 0xf2, 0xe1, 0xd9, 0xe2, 0xa4,
@@ -1064,5 +1045,31 @@ mod test {
         assert_eq!(x, minus_one);
         x.conditional_negate(1u8);
         assert_eq!(x, one);
+    }
+}
+
+#[cfg(test)]
+mod bench {
+    use test::Bencher;
+
+    use super::*;
+    use super::test::A_BYTES;
+
+    #[bench]
+    fn fieldelement_a_mul_a(b: &mut Bencher) {
+        let a = FieldElement::from_bytes(&A_BYTES);
+        b.iter(|| &a*&a);
+    }
+
+    #[bench]
+    fn fieldelement_a_sq(b: &mut Bencher) {
+        let a = FieldElement::from_bytes(&A_BYTES);
+        b.iter(|| a.square());
+    }
+
+    #[bench]
+    fn fieldelement_a_inv(b: &mut Bencher) {
+        let a = FieldElement::from_bytes(&A_BYTES);
+        b.iter(|| a.invert());
     }
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -1048,7 +1048,7 @@ mod test {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "bench"))]
 mod bench {
     use test::Bencher;
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -954,7 +954,7 @@ mod test {
          0x15, 0x21, 0xf9, 0xe3, 0xe1, 0x61, 0x21, 0x55];
 
     #[test]
-    fn test_fieldelement_a_mul_a() {
+    fn fieldelement_a_mul_a() {
         let a = FieldElement::from_bytes(&A_BYTES);
         let asq = FieldElement::from_bytes(&ASQ_BYTES);
         assert_eq!(asq, &a*&a);
@@ -962,35 +962,35 @@ mod test {
     }
 
     #[test]
-    fn test_fieldelement_a_square2() {
+    fn fieldelement_a_square2() {
         let a = FieldElement::from_bytes(&A_BYTES);
         let asq = FieldElement::from_bytes(&ASQ_BYTES);
         assert_eq!(a.square2(), &asq+&asq);
     }
 
     #[test]
-    fn test_fieldelement_a_inv() {
+    fn fieldelement_a_inv() {
         let a    = FieldElement::from_bytes(&A_BYTES);
         let ainv = FieldElement::from_bytes(&AINV_BYTES);
         assert_eq!(ainv, a.invert());
     }
 
     #[test]
-    fn test_fieldelement_a_p58() {
+    fn fieldelement_a_p58() {
         let a    = FieldElement::from_bytes(&A_BYTES);
         let ap58 = FieldElement::from_bytes(&AP58_BYTES);
         assert_eq!(ap58, a.pow_p58());
     }
 
     #[test]
-    fn test_fieldelement_a_chi() {
+    fn fieldelement_a_chi() {
         let a = FieldElement::from_bytes(&A_BYTES);
         // a is square
         assert_eq!(a.chi(), FieldElement::one());
     }
 
     #[test]
-    fn test_fieldelement_eq() {
+    fn fieldelement_eq() {
         let a    = FieldElement::from_bytes(&A_BYTES);
         let ainv = FieldElement::from_bytes(&AINV_BYTES);
         assert!(a == a);
@@ -1006,7 +1006,7 @@ mod test {
         [-5652623, 8034020, 8266223, -13556020, -5672552, -5582839, -12603138, 15161929, -16418207, 13296296]);
 
     #[test]
-    fn test_fieldelement_frombytes_highbit_is_ignored() {
+    fn fieldelement_frombytes_highbit_is_ignored() {
         let mut cleared_bytes = B_BYTES.clone();
         cleared_bytes[31] &= 127u8;
         let orig_elt = FieldElement::from_bytes(&B_BYTES);
@@ -1017,7 +1017,7 @@ mod test {
     }
 
     #[test]
-    fn test_fieldelement_to_bytes() {
+    fn fieldelement_to_bytes() {
         let test_elt = FieldElement::from_bytes(&B_BYTES);
         for i in 0..10 {
             assert!(test_elt[i] == B_LIMBS[i]);
@@ -1025,7 +1025,7 @@ mod test {
     }
 
     #[test]
-    fn test_fieldelement_from_bytes() {
+    fn fieldelement_from_bytes() {
         let test_bytes = B_LIMBS.to_bytes();
         for i in 0..31 {
             assert!(test_bytes[i] == B_BYTES[i]);
@@ -1035,7 +1035,7 @@ mod test {
     }
 
     #[test]
-    fn test_conditional_negate() {
+    fn conditional_negate() {
         let       one = FieldElement([ 1,0,0,0,0,0,0,0,0,0]);
         let minus_one = FieldElement([-1,0,0,0,0,0,0,0,0,0]);
         let mut x = one;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(collections))]
 #![allow(unused_features)]
-#![feature(test)]
+#![cfg_attr(feature = "bench", feature(test))]
 #![deny(missing_docs)] // refuse to compile if documentation is missing
 
 //! # curve25519-dalek
@@ -33,8 +33,9 @@
 //! hatred of the Daleks.  Rusty destroys the other Daleks and departs the
 //! ship, determined to track down and bring an end to the Dalek race.
 
-#[cfg(test)]
+#[cfg(all(test, feature = "bench"))]
 extern crate test;
+
 #[cfg(test)]
 extern crate sha2;
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -643,7 +643,7 @@ mod test {
          0,0,0,0,0,-15,0,0,0,0,0,15,0,0,0,0,15,0,0,0,0,15,0,0,0,0,0,1,0,0,0,0];
 
     #[test]
-    fn test_non_adjacent_form() {
+    fn non_adjacent_form() {
         let naf = A_SCALAR.non_adjacent_form();
         for i in 0..256 {
             assert_eq!(naf[i], A_NAF[i]);
@@ -651,7 +651,7 @@ mod test {
     }
 
     #[test]
-    fn test_scalar_multiply_by_one() {
+    fn scalar_multiply_by_one() {
         let one = Scalar::one();
         let zero = Scalar::zero();
         let test_scalar = Scalar::multiply_add(&X, &one, &zero);
@@ -661,7 +661,7 @@ mod test {
     }
 
     #[test]
-    fn test_scalar_multiply_only() {
+    fn scalar_multiply_only() {
         let zero = Scalar::zero();
         let test_scalar = Scalar::multiply_add(&X, &Y, &zero);
         for i in 0..32 {
@@ -670,7 +670,7 @@ mod test {
     }
 
     #[test]
-    fn test_scalar_multiply_add() {
+    fn scalar_multiply_add() {
         let test_scalar = Scalar::multiply_add(&X, &Y, &Z);
         for i in 0..32 {
             assert!(test_scalar[i] == W[i]);
@@ -678,7 +678,7 @@ mod test {
     }
 
     #[test]
-    fn test_scalar_reduce() {
+    fn scalar_reduce() {
         let mut bignum = [0u8;64];
         // set bignum = x + 2^256x
         for i in 0..32 {

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -592,44 +592,22 @@ impl UnpackedScalar {
 
 #[cfg(test)]
 mod test {
-    use rand::OsRng;
     use super::*;
-    use test::Bencher;
-
-    #[bench]
-    fn bench_scalar_random(b: &mut Bencher) {
-        let mut csprng: OsRng = OsRng::new().unwrap();
-
-        b.iter(|| Scalar::random(&mut csprng));
-    }
-
-    #[bench]
-    fn bench_scalar_multiply_add(b: &mut Bencher) {
-        b.iter(|| Scalar::multiply_add(&X, &Y, &Z) );
-    }
-
-    #[bench]
-    fn bench_scalar_unpacked_multiply_add(b: &mut Bencher) {
-        let x = X.unpack();
-        let y = Y.unpack();
-        let z = Z.unpack();
-        b.iter(|| UnpackedScalar::multiply_add(&x, &y, &z) );
-    }
 
     /// x = 2238329342913194256032495932344128051776374960164957527413114840482143558222
-    static X: Scalar = Scalar(
+    pub static X: Scalar = Scalar(
         [0x4e, 0x5a, 0xb4, 0x34, 0x5d, 0x47, 0x08, 0x84,
          0x59, 0x13, 0xb4, 0x64, 0x1b, 0xc2, 0x7d, 0x52,
          0x52, 0xa5, 0x85, 0x10, 0x1b, 0xcc, 0x42, 0x44,
          0xd4, 0x49, 0xf4, 0xa8, 0x79, 0xd9, 0xf2, 0x04]);
     /// y = 2592331292931086675770238855846338635550719849568364935475441891787804997264
-    static Y: Scalar = Scalar(
+    pub static Y: Scalar = Scalar(
         [0x90, 0x76, 0x33, 0xfe, 0x1c, 0x4b, 0x66, 0xa4,
          0xa2, 0x8d, 0x2d, 0xd7, 0x67, 0x83, 0x86, 0xc3,
          0x53, 0xd0, 0xde, 0x54, 0x55, 0xd4, 0xfc, 0x9d,
          0xe8, 0xef, 0x7a, 0xc3, 0x1f, 0x35, 0xbb, 0x05]);
     /// z = 5033871415930814945849241457262266927579821285980625165479289807629491019013
-    static Z: Scalar = Scalar(
+    pub static Z: Scalar = Scalar(
         [0x05, 0x9d, 0x3e, 0x0b, 0x09, 0x26, 0x50, 0x3d,
          0xa3, 0x84, 0xa1, 0x3c, 0x92, 0x7a, 0xc2, 0x06,
          0x41, 0x98, 0xcf, 0x34, 0x3a, 0x24, 0xd5, 0xb7,
@@ -721,10 +699,39 @@ mod test {
 
     // Negating a scalar twice should result in the original scalar.
     #[test]
-    fn test_scalar_neg() {
+    fn scalar_neg() {
         let negative_x: Scalar = -X;
         let orig: Scalar = -negative_x;
 
         assert!(orig == X);
+    }
+}
+
+#[cfg(test)]
+mod bench {
+    use rand::OsRng;
+    use test::Bencher;
+
+    use super::*;
+    use super::test::{X, Y, Z};
+
+    #[bench]
+    fn scalar_random(b: &mut Bencher) {
+        let mut csprng: OsRng = OsRng::new().unwrap();
+
+        b.iter(|| Scalar::random(&mut csprng));
+    }
+
+    #[bench]
+    fn scalar_multiply_add(b: &mut Bencher) {
+        b.iter(|| Scalar::multiply_add(&X, &Y, &Z) );
+    }
+
+    #[bench]
+    fn scalar_unpacked_multiply_add(b: &mut Bencher) {
+        let x = X.unpack();
+        let y = Y.unpack();
+        let z = Z.unpack();
+        b.iter(|| UnpackedScalar::multiply_add(&x, &y, &z) );
     }
 }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -707,7 +707,7 @@ mod test {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "bench"))]
 mod bench {
     use rand::OsRng;
     use test::Bencher;


### PR DESCRIPTION
This allows us to build (and run tests) on the stable and beta channels. `cargo bench` still only runs on nightly, since it's feature gated. To run the benchmarks, one must:

1) use nightly
2) do: `cargo bench --features="yolocrypto bench"`

This fixes the issue mentioned in #38.

It also cleans up some of the benchmarks by moving them to separate modules. (This part might cause conflicts. If so, I'll take responsibility for the cleanup.)