### PR TITLE
2nd attempt at fixing Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rust:
 env:
   - TEST_COMMAND=test FEATURES='yolocrypto'
   - TEST_COMMAND=test FEATURES='yolocrypto nightly'
+  - TEST_COMMAND=bench FEATURES='yolocrypto bench'
   - TEST_COMMAND=bench FEATURES='yolocrypto nightly bench'
 
 matrix:
@@ -16,6 +17,10 @@ matrix:
     # stable and beta, but currently we require "test" feature in order to
     # run benchmarks, which causes dalek not to build on stable.  See
     # https://github.com/isislovecruft/curve25519-dalek/pull/38#issuecomment-286027562
+    - rust: stable
+      env: TEST_COMMAND=bench FEATURES='yolocrypto bench'
+    - rust: beta
+      env: TEST_COMMAND=bench FEATURES='yolocrypto bench'
     - rust: stable
       env: TEST_COMMAND=bench FEATURES='yolocrypto nightly bench'
     - rust: beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rust:
 env:
   - TEST_COMMAND=test FEATURES='yolocrypto'
   - TEST_COMMAND=test FEATURES='yolocrypto nightly'
-  - TEST_COMMAND=bench FEATURES='yolocrypto bench'
+  - TEST_COMMAND=bench FEATURES='yolocrypto nightly bench'
 
 matrix:
   exclude:
@@ -17,9 +17,9 @@ matrix:
     # run benchmarks, which causes dalek not to build on stable.  See
     # https://github.com/isislovecruft/curve25519-dalek/pull/38#issuecomment-286027562
     - rust: stable
-      env: TEST_COMMAND=bench FEATURES='yolocrypto bench'
+      env: TEST_COMMAND=bench FEATURES='yolocrypto nightly bench'
     - rust: beta
-      env: TEST_COMMAND=bench FEATURES='yolocrypto bench'
+      env: TEST_COMMAND=bench FEATURES='yolocrypto nightly bench'
     # Test nightly features, such as radix_51, only on nightly.
     - rust: stable
       env: TEST_COMMAND=test FEATURES='yolocrypto nightly'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
 
 env:
   - TEST_COMMAND=test FEATURES='yolocrypto'
-  - TEST_COMMAND=test FEATURES='yolocrypto radix_51'
+  - TEST_COMMAND=test FEATURES='yolocrypto nightly'
   - TEST_COMMAND=bench FEATURES='yolocrypto bench'
 
 matrix:
@@ -20,11 +20,11 @@ matrix:
       env: TEST_COMMAND=bench FEATURES='yolocrypto bench'
     - rust: beta
       env: TEST_COMMAND=bench FEATURES='yolocrypto bench'
-    # radix_51 requires nightly for u128
+    # Test nightly features, such as radix_51, only on nightly.
     - rust: stable
-      env: TEST_COMMAND=test FEATURES='yolocrypto radix_51'
+      env: TEST_COMMAND=test FEATURES='yolocrypto nightly'
     - rust: beta
-      env: TEST_COMMAND=test FEATURES='yolocrypto radix_51'
+      env: TEST_COMMAND=test FEATURES='yolocrypto nightly'
 
 script:
   - cargo $TEST_COMMAND --features="$FEATURES"


### PR DESCRIPTION
Test nightly features on nightly channel.  I merged the previous one since I thought I had introduced an error while refactoring the `cfg` gating for `radix_51`, but I think it was instead an error in the Travis config.