### PR TITLE
Add Serde support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rust:
 
 env:
   - TEST_COMMAND=test FEATURES=--features="yolocrypto"
+  - TEST_COMMAND=test FEATURES=--features="yolocrypto serde"
   - TEST_COMMAND=test FEATURES=--features="yolocrypto nightly"
   - TEST_COMMAND=bench FEATURES=--features="yolocrypto bench"
   - TEST_COMMAND=bench FEATURES=--features="yolocrypto nightly bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,15 @@ exclude = [
 [badges]
 travis-ci = { repository = "isislovecruft/curve25519-dalek", branch = "master"}
 
+[dependencies.serde]
+version = "1.0"
+
+[dependencies.serde_json]
+version = "1.0"
+
+[dependencies.serde_cbor]
+version = "0.6"
+
 [dependencies.arrayref]
 version = "0.3.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,7 @@ travis-ci = { repository = "isislovecruft/curve25519-dalek", branch = "master"}
 
 [dependencies.serde]
 version = "1.0"
-
-[dependencies.serde_json]
-version = "1.0"
-
-[dependencies.serde_cbor]
-version = "0.6"
+optional = true
 
 [dependencies.arrayref]
 version = "0.3.3"
@@ -43,6 +38,9 @@ version = "^0.6"
 
 [dev-dependencies.sha2]
 version = "0.4"
+
+[dev-dependencies.serde_cbor]
+version = "0.6"
 
 [features]
 nightly = ["radix_51"]

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -1643,19 +1643,16 @@ mod test {
         assert_eq!(parsed.compress_edwards(), constants::BASE_CMPRSSD);
     }
 
-    /*
-    use serde_json;
-
     #[test]
-    fn serde_json_basepoint_roundtrip() {
-        let output = serde_json::to_string(&constants::ED25519_BASEPOINT).unwrap();
-        println!("{:?}", output);
-        println!("{:?}", constants::BASE_CMPRSSD);
-        let parsed: ExtendedPoint = serde_json::from_str(&output).unwrap();
-        println!("{:?}", parsed);
-        panic!();
+    #[cfg(feature = "serde")]
+    fn serde_cbor_decode_invalid_fails() {
+        let mut output = serde_cbor::to_vec(&constants::ED25519_BASEPOINT).unwrap();
+        // CBOR apparently has two bytes of overhead for a 32-byte string.
+        // Set the low byte of the compressed point to 1 to make it invalid.
+        output[2] = 1;
+        let parsed: Result<ExtendedPoint,_> = serde_cbor::from_slice(&output);
+        assert!(parsed.is_err());
     }
-    */
 }
 
 // ------------------------------------------------------------------------

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -317,7 +317,6 @@ impl<'de> Deserialize<'de> for ExtendedPoint {
             fn visit_bytes<E>(self, v: &[u8]) -> Result<ExtendedPoint, E>
                 where E: serde::de::Error
             {
-                println!("VISIT_BYTES");
                 if v.len() == 32 {
                     let arr32 = array_ref!(v,0,32); // &[u8;32] from &[u8]
                     CompressedEdwardsY(*arr32).decompress()
@@ -328,7 +327,6 @@ impl<'de> Deserialize<'de> for ExtendedPoint {
             }
         }
 
-        println!("DESERIALIZE");
         deserializer.deserialize_bytes(ExtendedPointVisitor)
     }
 }

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -286,11 +286,12 @@ impl CompressedMontgomeryU {
 // structs containing `ExtendedPoint`s and use Serde's derived
 // serializers to serialize those structures.
 
-use serde::{Serialize, Deserialize};
-use serde::{Serializer, Deserializer};
+#[cfg(feature = "serde")]
+use serde::{self, Serialize, Deserialize, Serializer, Deserializer};
+#[cfg(feature = "serde")]
 use serde::de::Visitor;
-use serde;
 
+#[cfg(feature = "serde")]
 impl Serialize for ExtendedPoint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
@@ -299,6 +300,7 @@ impl Serialize for ExtendedPoint {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for ExtendedPoint {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: Deserializer<'de>
@@ -1610,7 +1612,7 @@ mod test {
     mod vartime {
         use super::super::*;
         use super::{A_SCALAR, B_SCALAR, A_TIMES_BASEPOINT, DOUBLE_SCALAR_MULT_RESULT};
-        
+
         /// Test double_scalar_mult_vartime vs ed25519.py
         #[test]
         fn double_scalar_mult_basepoint_vs_ed25519py() {
@@ -1630,9 +1632,11 @@ mod test {
         }
     }
 
+    #[cfg(feature = "serde")]
     use serde_cbor;
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_cbor_basepoint_roundtrip() {
         let output = serde_cbor::to_vec(&constants::ED25519_BASEPOINT).unwrap();
         let parsed: ExtendedPoint = serde_cbor::from_slice(&output).unwrap();

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -116,11 +116,12 @@ impl Identity for CompressedDecaf {
 // structs containing `DecafPoint`s and use Serde's derived
 // serializers to serialize those structures.
 
-use serde::{Serialize, Deserialize};
-use serde::{Serializer, Deserializer};
+#[cfg(feature = "serde")]
+use serde::{self, Serialize, Deserialize, Serializer, Deserializer};
+#[cfg(feature = "serde")]
 use serde::de::Visitor;
-use serde;
 
+#[cfg(feature = "serde")]
 impl Serialize for DecafPoint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where S: Serializer
@@ -129,6 +130,7 @@ impl Serialize for DecafPoint {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for DecafPoint {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: Deserializer<'de>
@@ -436,9 +438,11 @@ mod test {
     use curve::Identity;
     use super::*;
 
+    #[cfg(feature = "serde")]
     use serde_cbor;
 
     #[test]
+    #[cfg(feature = "serde")]
     fn serde_cbor_basepoint_roundtrip() {
         let output = serde_cbor::to_vec(&constants::DECAF_ED25519_BASEPOINT).unwrap();
         let parsed: DecafPoint = serde_cbor::from_slice(&output).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,11 @@ extern crate arrayref;
 extern crate generic_array;
 extern crate digest;
 
+//#[cfg(feature = "serde")]
+extern crate serde;
+extern crate serde_cbor;
+extern crate serde_json;
+
 #[cfg(feature = "std")]
 extern crate core;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,10 +47,10 @@ extern crate arrayref;
 extern crate generic_array;
 extern crate digest;
 
-//#[cfg(feature = "serde")]
+#[cfg(feature = "serde")]
 extern crate serde;
+#[cfg(all(test, feature = "serde"))]
 extern crate serde_cbor;
-extern crate serde_json;
 
 #[cfg(feature = "std")]
 extern crate core;


### PR DESCRIPTION
The serializable objects are `ExtendedPoint`s, `DecafPoint`s, and `Scalar`s.

Point decompression happens in the `Deserialize` implementation, causing a parse error on decompression.  Users can therefore derive `Serialize, Deserialize` on structs containing points; input data will either deserialize correctly to structs containing valid points, or not at all.

This code is currently not compatible with `serde_json`, because JSON doesn't have a native byte string type.  The `serde_json` backend seems to serialize a byte string as an array; deserialization fails because the parser sees an array, not a byte string, and `visit_bytes` is never called.  I'm not sure it's worthwhile to put in a workaround to allow support for a data format that doesn't have byte strings.