### PR TITLE
Fix overflow bug in Decaf Elligator code

### DIFF
--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -671,7 +671,7 @@ mod test {
     #[test]
     fn decaf_random_is_valid() {
         let mut rng = OsRng::new().unwrap();
-        for _ in 0..100_000 {
+        for _ in 0..10_000 {
             let P = DecafPoint::random(&mut rng);
             // Check that P is on the curve
             assert!(P.0.is_valid());

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -666,7 +666,7 @@ mod test {
     #[test]
     fn decaf_random_is_valid() {
         let mut rng = OsRng::new().unwrap();
-        for _ in 0..100 {
+        for _ in 0..100_000 {
             let P = DecafPoint::random(&mut rng);
             // Check that P is on the curve
             assert!(P.0.is_valid());

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -267,6 +267,7 @@ impl DecafPoint {
     fn elligator_decaf_flavour(r_0: &FieldElement) -> DecafPoint {
         // Follows Appendix C of the Decaf paper.
         // Use n = 2 as the quadratic nonresidue so that n*x = x + x.
+        let minus_one = -&FieldElement::one();
 
         // 1. Compute r <--- nr_0^2.
         let r_0_squared = r_0.square();
@@ -274,11 +275,15 @@ impl DecafPoint {
 
         // 2. Compute D <--- (dr + (a-d)) * (dr - (d + ar)) 
         let dr = &constants::d * &r;
-        // D = (dr + (a-d)) * (dr - (d + ar)) = (dr + (a-d))*(dr - (d-r)) since a=-1
-        let D = &(&dr + &constants::a_minus_d) * &(&dr - &(&constants::d - &r));
+        // D = (dr + (a-d)) * (dr - (d + ar))
+        //   = (dr + (a-d)) * (dr - (d-r)) since a=-1
+        // writing as
+        //   = (dr + (a-d)) * dr - (dr + (a-d)) * (d - r)
+        // avoids two consecutive additions (could cause overflow)
+        let dr_plus_amd = &dr + &constants::a_minus_d;
+        let D = &(&dr_plus_amd * &dr) - &(&dr_plus_amd * &(&constants::d - &r));
 
         // 3. Compute N <--- (r+1) * (a-2d)
-        let minus_one = -&FieldElement::one();
         let N = &(&r + &FieldElement::one()) * &(&minus_one - &constants::d2);
 
         // 4. Compute


### PR DESCRIPTION
The implementation of Elligator-flavoured Decaf I wrote had an overflow bug, caused by a too-long sequence of additions of `FieldElements`.  This is a problem for the default 32-bit implementation, but not for the 64-bit `radix_51` implementation, which I was using when I wrote the code.

Because Rust traps overflows in debug builds, this bug was caught by the unit test.  However, it would be good to try to prevent the same mistake in the future.

# Static checking

I think it's possible to do this in a hacky way now, but it would be extremely ugly and coarse, creating a new type name for each interval.  

Const generics, as in [Rust RFC 2000](https://github.com/rust-lang/rfcs/pull/2000), would allow clean but coarse-grained (e.g., "number of bits of headroom) static analysis. I think waiting for this is the best option.

Pi types 2, as in [Rust RFC 1932](https://github.com/rust-lang/rfcs/pull/1932), would allow clean and fine-grained (exact bounds) static analysis.  Unfortunately, it's postponed indefinitely in favour of RFC 2000.

Some other notes on static analysis are in [this comment](https://github.com/isislovecruft/curve25519-dalek/blob/b97868beb80170e734563d2ba8a546acfa40c90d/src/field.rs#L165L175); I am not sure whether that could be implemented with RFC 2000, because it might require unification of types that wouldn't be unified in that proposal. On unification, see also [this comment](https://github.com/rust-lang/rfcs/pull/2000#discussion_r116134423).

# Dynamic checking

Rust traps overflows in debug builds, allowing dynamic checking/fuzzing, which caught this bug.  The 64-bit `radix_51` implementation, which is written from scratch, includes many `debug_assert!`s to detect bounds failures.  Of course, in release builds, all of this code is omitted to produce constant-time branch-free code.

The 32-bit implementation, which was ported from ed25519.go (which was ported from ref10), is considerably less clean, and has far fewer checks.  I think it would be good to rewrite it to match the quality level of the 64-bit code.

We already do dynamic checking [here](https://github.com/isislovecruft/curve25519-dalek/blob/b97868beb80170e734563d2ba8a546acfa40c90d/src/curve.rs#L1556-L1574), which does 1,000 scalar multiplications (causing about 1M each of field multiplications and squarings).

The initial test for Decaf-Elligator used only 100 samples, which wasn't sufficient to reliably detect the overflow, which I think is why it wasn't detected by Travis CI.  

@manishearth suggested using [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz); maybe it would be better to move dynamic checking into a fuzzing module, so that it can be run seperately from the unit tests?
