### PR TITLE
Switch from libcollections to liballoc (gated on an "alloc" feature)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ matrix:
       env: TEST_COMMAND=build EXTRA_FLAGS=--no-default-features FEATURES=''
     - rust: beta
       env: TEST_COMMAND=build EXTRA_FLAGS=--no-default-features FEATURES=''
+    - rust: nightly
+      env: TEST_COMMAND=build EXTRA_FLAGS=--no-default-features FEATURES='alloc'
 
 script:
   - cargo $TEST_COMMAND --features="$FEATURES" $EXTRA_FLAGS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ version = "0.6"
 nightly = ["radix_51"]
 default = ["std"]
 std = ["rand"]
+alloc = []
 yolocrypto = []
 bench = []
 # Radix-51 arithmetic using u128

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -77,8 +77,8 @@
 // affine and projective cakes and eat both of them too.
 #![allow(non_snake_case)]
 
-#[cfg(not(feature = "std"))]
-use collections::Vec;
+#[cfg(feature = "alloc")]
+use alloc::Vec;
 
 use core::fmt::Debug;
 use core::iter::Iterator;
@@ -1195,6 +1195,7 @@ pub mod vartime {
     ///
     /// A vector of `Scalar`s and a vector of `ExtendedPoints`.  It is an
     /// error to call this function with two vectors of different lengths.
+    #[cfg(any(feature = "alloc", feature = "std"))]
     pub fn k_fold_scalar_mult<'a,'b,I,J>(scalars: I, points: J) -> ExtendedPoint
         where I: IntoIterator<Item=&'a Scalar>, J: IntoIterator<Item=&'b ExtendedPoint>
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //  - Henry de Valence <hdevalence@hdevalence.ca>
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(collections))]
+#![cfg_attr(feature = "alloc", feature(alloc))]
 #![cfg_attr(feature = "nightly", feature(i128_type))]
 #![cfg_attr(feature = "bench", feature(test))]
 
@@ -58,8 +58,8 @@ extern crate core;
 #[cfg(feature = "std")]
 extern crate rand;
 
-#[cfg(not(feature = "std"))]
-extern crate collections;
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 // Modules for low-level operations directly on field elements and curve points.
 


### PR DESCRIPTION
libcollections was recently merged into liballoc:

https://github.com/rust-lang/rust/pull/42648

This breaks curve25519-dalek when used with `no_std` on recent nightlies.

I went ahead and also added an "alloc" feature which no_std users can use to opt
into liballoc features (i.e. any code using Vec). This should have no effect on
anything but no_std usage. It does make it possible for people without
allocators to use curve25519-dalek if they want though. Might be nice for
"bare metal" development.

All that said, from what I can gather liballoc, while not "stable", should
likely stick around for the forseeable future.

Some backstory on the liballoc/libcollections merge here:

https://github.com/rust-lang/rust/pull/42565