### PR TITLE
Update sha2 and digest deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,14 @@ optional = true
 version = "0.3"
 
 [dependencies.digest]
-version = "0.4"
+version = "0.6"
 
 [dependencies.generic-array]
 # same version that digest depends on
 version = "^0.6"
 
 [dev-dependencies.sha2]
-version = "0.4"
+version = "0.6"
 
 [dev-dependencies.serde_cbor]
 version = "0.6"


### PR DESCRIPTION
Previously, it was impossible to use an 0.6 version RustHash library with curve25519-dalek. The error when `from_hash` was called looked like `The trait digest::Digest is not implemented for sha2::Sha256`. After this change, code using version 0.6 compiles and runs correctly.