### PR TITLE
Only pull in subtle's std feature if "std" is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ version = "0.6"
 
 [dependencies.subtle]
 version = "^0.1"
+default-features = false
 
 [dependencies.generic-array]
 # same version that digest depends on
@@ -48,7 +49,7 @@ version = "0.6"
 [features]
 nightly = ["radix_51"]
 default = ["std"]
-std = ["rand"]
+std = ["rand", "subtle/std"]
 alloc = []
 yolocrypto = []
 bench = []


### PR DESCRIPTION
Otherwise subtle implicitly pulls in std because it's a default feature.

Tested and confirmed working in our `no_std` environment.