### PR TITLE
Add constant time k-fold scalar mult

### DIFF
--- a/src/curve.rs
+++ b/src/curve.rs
@@ -944,15 +944,12 @@ impl<'a, 'b> Mul<&'b ExtendedPoint> for &'a Scalar {
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn multiscalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> ExtendedPoint
     where I: IntoIterator<Item = &'a Scalar>,
-          I::IntoIter: ExactSizeIterator,
-          J: IntoIterator<Item = &'b ExtendedPoint>,
-          J::IntoIter: ExactSizeIterator,
+            J: IntoIterator<Item = &'b ExtendedPoint>
 {
-    let scalars_iter = scalars.into_iter();
-    let points_iter = points.into_iter();
-    assert_eq!(scalars_iter.len(), points_iter.len());
+    //assert_eq!(scalars.len(), points.len());
 
-    let lookup_tables: Vec<_> = points_iter.map(|P_i| {
+    let lookup_tables: Vec<_> = points.into_iter()
+        .map(|P_i| {
             // Construct a lookup table of [P_i,2*P_i,3*P_i,4*P_i,5*P_i,6*P_i,7*P_i]
             let mut lookup_table = [P_i.to_projective_niels(); 8];
             for j in 0..7 {
@@ -967,7 +964,8 @@ pub fn multiscalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> ExtendedPoint
     //    s_i = s_{i,0} + s_{i,1}*16^1 + ... + s_{i,63}*16^63,
     //
     // with `-8 ≤ s_{i,j} < 8` for `0 ≤ j < 63` and `-8 ≤ s_{i,63} ≤ 8`.
-    let scalar_digits_list: Vec<_> = scalars_iter.map(|c| c.to_radix_16()).collect();
+    let scalar_digits_list: Vec<_> = scalars.into_iter()
+        .map(|c| c.to_radix_16()).collect();
 
     // Compute s_1*P_1 + ... + s_n*P_n: since
     //
@@ -1285,18 +1283,15 @@ pub mod vartime {
     /// error to call this function with two vectors of different lengths.
     #[cfg(any(feature = "alloc", feature = "std"))]
     pub fn multiscalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> ExtendedPoint
-        where
-            I: IntoIterator<Item = &'a Scalar>,
-            I::IntoIter: ExactSizeIterator,
-            J: IntoIterator<Item = &'b ExtendedPoint>,
-            J::IntoIter: ExactSizeIterator,
+        where I: IntoIterator<Item = &'a Scalar>,
+              J: IntoIterator<Item = &'b ExtendedPoint>
     {
-        let scalars_iter = scalars.into_iter();
-        let points_iter = points.into_iter();
-        assert_eq!(scalars_iter.len(), points_iter.len());
+        //assert_eq!(scalars.len(), points.len());
 
-        let nafs: Vec<_> = scalars_iter.map(|c| c.non_adjacent_form()).collect();
-        let odd_multiples: Vec<_> = points_iter.map(|P| OddMultiples::create(P)).collect();
+        let nafs: Vec<_> = scalars.into_iter()
+            .map(|c| c.non_adjacent_form()).collect();
+        let odd_multiples: Vec<_> = points.into_iter()
+            .map(|P| OddMultiples::create(P)).collect();
 
         let mut r = ProjectivePoint::identity();
 
@@ -1706,15 +1701,6 @@ mod test {
         assert!(P1.compress().as_bytes() == P2.compress().as_bytes());
     }
 
-    #[test]
-    #[should_panic]
-    fn multiscalar_mult_with_wrong_sized_arguments() {
-        let result = multiscalar_mult(
-            &[A_SCALAR, B_SCALAR],
-            &[constants::ED25519_BASEPOINT],
-        );
-    }
-
     mod vartime {
         use super::super::*;
         use super::{A_SCALAR, B_SCALAR, A_TIMES_BASEPOINT, DOUBLE_SCALAR_MULT_RESULT};
@@ -1725,15 +1711,6 @@ mod test {
             let A = A_TIMES_BASEPOINT.decompress().unwrap();
             let result = vartime::double_scalar_mult_basepoint(&A_SCALAR, &A, &B_SCALAR);
             assert_eq!(result.compress_edwards(), DOUBLE_SCALAR_MULT_RESULT);
-        }
-
-        #[test]
-        #[should_panic]
-        fn multiscalar_mult_with_wrong_sized_arguments() {
-            let result = vartime::multiscalar_mult(
-                &[A_SCALAR, B_SCALAR],
-                &[constants::ED25519_BASEPOINT],
-            );
         }
 
         #[test]

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -935,14 +935,14 @@ impl<'a, 'b> Mul<&'b ExtendedPoint> for &'a Scalar {
 /// (possibly secret) points, compute `c_1 P_1 + ... + c_n P_n`.
 ///
 /// This function has the same behaviour as
-/// `vartime::k_fold_scalar_mult` but is constant-time.
+/// `vartime::multiscalar_mult` but is constant-time.
 ///
 /// # Input
 ///
 /// A vector of `Scalar`s and a vector of `ExtendedPoints`.  It is an
 /// error to call this function with two vectors of different lengths.
 #[cfg(any(feature = "alloc", feature = "std"))]
-pub fn k_fold_scalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> ExtendedPoint
+pub fn multiscalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> ExtendedPoint
     where I: IntoIterator<Item = &'a Scalar>,
             J: IntoIterator<Item = &'b ExtendedPoint>
 {
@@ -1281,7 +1281,7 @@ pub mod vartime {
     /// A vector of `Scalar`s and a vector of `ExtendedPoints`.  It is an
     /// error to call this function with two vectors of different lengths.
     #[cfg(any(feature = "alloc", feature = "std"))]
-    pub fn k_fold_scalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> ExtendedPoint
+    pub fn multiscalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> ExtendedPoint
         where I: IntoIterator<Item = &'a Scalar>,
               J: IntoIterator<Item = &'b ExtendedPoint>
     {
@@ -1713,9 +1713,9 @@ mod test {
         }
 
         #[test]
-        fn k_fold_scalar_mult_vs_ed25519py() {
+        fn multiscalar_mult_vs_ed25519py() {
             let A = A_TIMES_BASEPOINT.decompress().unwrap();
-            let result = vartime::k_fold_scalar_mult(
+            let result = vartime::multiscalar_mult(
                 &[A_SCALAR, B_SCALAR],
                 &[A, constants::ED25519_BASEPOINT]
             );
@@ -1723,13 +1723,13 @@ mod test {
         }
 
         #[test]
-        fn k_fold_scalar_mult_vartime_vs_consttime() {
+        fn multiscalar_mult_vartime_vs_consttime() {
             let A = A_TIMES_BASEPOINT.decompress().unwrap();
-            let result_vartime = vartime::k_fold_scalar_mult(
+            let result_vartime = vartime::multiscalar_mult(
                 &[A_SCALAR, B_SCALAR],
                 &[A, constants::ED25519_BASEPOINT]
             );
-            let result_consttime = k_fold_scalar_mult(
+            let result_consttime = multiscalar_mult(
                 &[A_SCALAR, B_SCALAR],
                 &[A, constants::ED25519_BASEPOINT]
             );
@@ -1871,7 +1871,7 @@ mod bench {
         let B = &constants::ED25519_BASEPOINT_TABLE;
         let points: Vec<_> = scalars.iter().map(|s| B * &s).collect();
 
-        b.iter(|| k_fold_scalar_mult(&scalars, &points));
+        b.iter(|| multiscalar_mult(&scalars, &points));
     }
 
     mod vartime {
@@ -1900,7 +1900,7 @@ mod bench {
             //
             // Since this is a variable-time function, this means the
             // benchmark is only useful as a ballpark measurement.
-            b.iter(|| vartime::k_fold_scalar_mult(&scalars, &points));
+            b.iter(|| vartime::multiscalar_mult(&scalars, &points));
         }
     }
 }

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -987,6 +987,7 @@ pub fn multiscalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> ExtendedPoint
     // mults: we perform 63 multiplications by 16 instead of 63*n
     // multiplications, saving 252*(n-1) doublings.
     let mut Q = ExtendedPoint::identity();
+    // XXX this algorithm makes no effort to be cache-aware; maybe it could be improved?
     for j in (0..64).rev() {
         Q = Q.mult_by_pow_2(4);
         let it = scalar_digits_list.iter().zip(lookup_tables.iter());

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -948,14 +948,6 @@ pub fn multiscalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> ExtendedPoint
 {
     //assert_eq!(scalars.len(), points.len());
 
-    // Setting s_i = i-th scalar, compute
-    //
-    //    s_i = s_{i,0} + s_{i,1}*16^1 + ... + s_{i,63}*16^63,
-    //
-    // with `-8 ≤ s_{i,j} < 8` for `0 ≤ j < 63` and `-8 ≤ s_{i,63} ≤ 8`.
-    let scalar_digits_list: Vec<_> = scalars.into_iter()
-        .map(|c| c.to_radix_16()).collect();
-
     let lookup_tables: Vec<_> = points.into_iter()
         .map(|P_i| {
             // Construct a lookup table of [P_i,2*P_i,3*P_i,4*P_i,5*P_i,6*P_i,7*P_i]
@@ -966,6 +958,14 @@ pub fn multiscalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> ExtendedPoint
             }
             lookup_table
         }).collect();
+
+    // Setting s_i = i-th scalar, compute
+    //
+    //    s_i = s_{i,0} + s_{i,1}*16^1 + ... + s_{i,63}*16^63,
+    //
+    // with `-8 ≤ s_{i,j} < 8` for `0 ≤ j < 63` and `-8 ≤ s_{i,63} ≤ 8`.
+    let scalar_digits_list: Vec<_> = scalars.into_iter()
+        .map(|c| c.to_radix_16()).collect();
 
     // Compute s_1*P_1 + ... + s_n*P_n: since
     //

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -884,20 +884,38 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a ExtendedPoint {
     /// Uses a window of size 4.  Note: for scalar multiplication of
     /// the basepoint, `basepoint_mult` is approximately 4x faster.
     fn mul(self, scalar: &'b Scalar) -> ExtendedPoint {
-        let A = self.to_projective_niels();
-        let mut As: [ProjectiveNielsPoint; 8] = [A; 8];
+        // Construct a lookup table of [P,2P,3P,4P,5P,6P,7P,8P]
+        let P = self.to_projective_niels();
+        let mut lookup_table: [ProjectiveNielsPoint; 8] = [P; 8];
         for i in 0..7 {
-            As[i+1] = (self + &As[i]).to_extended().to_projective_niels();
+            lookup_table[i+1] = (self + &lookup_table[i])
+                .to_extended().to_projective_niels();
         }
-        let e = scalar.to_radix_16();
-        let mut h = ExtendedPoint::identity();
-        let mut t: CompletedPoint;
+
+        // Setting s = scalar, compute
+        //
+        //    s = s_0 + s_1*16^1 + ... + s_63*16^63,
+        //
+        // with `-8 ≤ s_i < 8` for `0 ≤ i < 63` and `-8 ≤ s_63 ≤ 8`.
+        let scalar_digits = scalar.to_radix_16();
+
+        // Compute s*P as
+        //
+        //    s*P = P*(s_0 +   s_1*16^1 +   s_2*16^2 + ... +   s_63*16^63)
+        //    s*P =  P*s_0 + P*s_1*16^1 + P*s_2*16^2 + ... + P*s_63*16^63
+        //    s*P = P*s_0 + 16*(P*s_1 + 16*(P*s_2 + 16*( ... + P*s_63)...))
+        //
+        // We sum right-to-left.
+        let mut Q = ExtendedPoint::identity();
         for i in (0..64).rev() {
-            h = h.mult_by_pow_2(4);
-            t = &h + &select_precomputed_point(e[i], &As);
-            h = t.to_extended();
+            // Q = 16*Q
+            Q = Q.mult_by_pow_2(4);
+            // R = s_i * Q
+            let R = select_precomputed_point(scalar_digits[i], &lookup_table);
+            // Q = Q + R
+            Q = (&Q + &R).to_extended();
         }
-        h
+        Q
     }
 }
 
@@ -913,6 +931,74 @@ impl<'a, 'b> Mul<&'b ExtendedPoint> for &'a Scalar {
     }
 }
 
+/// Given a vector of (possibly secret) scalars and a vector of
+/// (possibly secret) points, compute `c_1 P_1 + ... + c_n P_n`.
+///
+/// This function has the same behaviour as
+/// `vartime::k_fold_scalar_mult` but is constant-time.
+///
+/// # Input
+///
+/// A vector of `Scalar`s and a vector of `ExtendedPoints`.  It is an
+/// error to call this function with two vectors of different lengths.
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn k_fold_scalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> ExtendedPoint
+    where I: IntoIterator<Item = &'a Scalar>,
+            J: IntoIterator<Item = &'b ExtendedPoint>
+{
+    //assert_eq!(scalars.len(), points.len());
+
+    // Setting s_i = i-th scalar, compute
+    //
+    //    s_i = s_{i,0} + s_{i,1}*16^1 + ... + s_{i,63}*16^63,
+    //
+    // with `-8 ≤ s_{i,j} < 8` for `0 ≤ j < 63` and `-8 ≤ s_{i,63} ≤ 8`.
+    let scalar_digits_list: Vec<_> = scalars.into_iter()
+        .map(|c| c.to_radix_16()).collect();
+
+    let lookup_tables: Vec<_> = points.into_iter()
+        .map(|P_i| {
+            // Construct a lookup table of [P_i,2*P_i,3*P_i,4*P_i,5*P_i,6*P_i,7*P_i]
+            let mut lookup_table = [P_i.to_projective_niels(); 8];
+            for j in 0..7 {
+                lookup_table[j+1] = (P_i + &lookup_table[j])
+                    .to_extended().to_projective_niels();
+            }
+            lookup_table
+        }).collect();
+
+    // Compute s_1*P_1 + ... + s_n*P_n: since
+    //
+    //    s_i*P_i = P_i*(s_{i,0} +     s_{i,1}*16^1 + ... +     s_{i,63}*16^63)
+    //    s_i*P_i =  P_i*s_{i,0} + P_i*s_{i,1}*16^1 + ... + P_i*s_{i,63}*16^63
+    //    s_i*P_i =  P_i*s_{i,0} + 16*(P_i*s_{i,1} + 16*( ... + 16*P_i*s_{i,63})...)
+    //
+    // we have the two-dimensional sum
+    //
+    //    s_1*P_1 =   P_1*s_{1,0} + 16*(P_1*s_{1,1} + 16*( ... + 16*P_1*s_{1,63})...)
+    //  + s_2*P_2 = + P_2*s_{2,0} + 16*(P_2*s_{2,1} + 16*( ... + 16*P_2*s_{2,63})...)
+    //      ...
+    //  + s_n*P_n = + P_n*s_{n,0} + 16*(P_n*s_{n,1} + 16*( ... + 16*P_n*s_{n,63})...)
+    //
+    // We sum column-wise top-to-bottom, then right-to-left,
+    // multiplying by 16 only once per column.
+    //
+    // This provides the speedup over doing n independent scalar
+    // mults: we perform 63 multiplications by 16 instead of 63*n
+    // multiplications, saving 252*(n-1) doublings.
+    let mut Q = ExtendedPoint::identity();
+    for j in (0..64).rev() {
+        Q = Q.mult_by_pow_2(4);
+        let it = scalar_digits_list.iter().zip(lookup_tables.iter());
+        for (s_i, lookup_table_i) in it {
+            // R_i = s_{i,j} * P_i
+            let R_i = select_precomputed_point(s_i[j], lookup_table_i);
+            // Q = Q + R_i
+            Q = (&Q + &R_i).to_extended();
+        }
+    }
+    Q
+}
 
 /// Precomputation
 #[derive(Clone)]
@@ -1635,6 +1721,21 @@ mod test {
             );
             assert_eq!(result.compress_edwards(), DOUBLE_SCALAR_MULT_RESULT);
         }
+
+        #[test]
+        fn k_fold_scalar_mult_vartime_vs_consttime() {
+            let A = A_TIMES_BASEPOINT.decompress().unwrap();
+            let result_vartime = vartime::k_fold_scalar_mult(
+                &[A_SCALAR, B_SCALAR],
+                &[A, constants::ED25519_BASEPOINT]
+            );
+            let result_consttime = k_fold_scalar_mult(
+                &[A_SCALAR, B_SCALAR],
+                &[A, constants::ED25519_BASEPOINT]
+            );
+
+            assert_eq!(result_vartime.compress_edwards(), result_consttime.compress_edwards());
+        }
     }
 
     #[cfg(feature = "serde")]
@@ -1759,6 +1860,18 @@ mod bench {
     fn create_basepoint_table(b: &mut Bencher) {
         let aB = &constants::ED25519_BASEPOINT_TABLE * &A_SCALAR;
         b.iter(|| EdwardsBasepointTable::create(&aB));
+    }
+
+    #[bench]
+    fn ten_fold_scalar_mult(b: &mut Bencher) {
+        let mut csprng: OsRng = OsRng::new().unwrap();
+        // Create 10 random scalars
+        let scalars: Vec<_> = (0..10).map(|_| Scalar::random(&mut csprng)).collect();
+        // Create 10 points (by doing scalar mults)
+        let B = &constants::ED25519_BASEPOINT_TABLE;
+        let points: Vec<_> = scalars.iter().map(|s| B * &s).collect();
+
+        b.iter(|| k_fold_scalar_mult(&scalars, &points));
     }
 
     mod vartime {

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -683,12 +683,12 @@ pub mod vartime {
     ///
     /// A vector of `Scalar`s and a vector of `ExtendedPoints`.  It is an
     /// error to call this function with two vectors of different lengths.
-    pub fn k_fold_scalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> DecafPoint
+    pub fn multiscalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> DecafPoint
         where I: IntoIterator<Item = &'a Scalar>,
               J: IntoIterator<Item = &'b DecafPoint>
     {
         let extended_points = points.into_iter().map(|P| &P.0);
-        DecafPoint(curve::vartime::k_fold_scalar_mult(scalars, extended_points))
+        DecafPoint(curve::vartime::multiscalar_mult(scalars, extended_points))
     }
 }
 

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -577,6 +577,24 @@ impl<'a, 'b> Mul<&'b DecafPoint> for &'a Scalar {
     }
 }
 
+/// Given a vector of (possibly secret) scalars and a vector of
+/// (possibly secret) points, compute `c_1 P_1 + ... + c_n P_n`.
+///
+/// This function has the same behaviour as
+/// `vartime::multiscalar_mult` but is constant-time.
+///
+/// # Input
+///
+/// A vector of `Scalar`s and a vector of `DecafPoints`.  It is an
+/// error to call this function with two vectors of different lengths.
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn multiscalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> DecafPoint
+    where I: IntoIterator<Item = &'a Scalar>,
+          J: IntoIterator<Item = &'b DecafPoint>,
+{
+    let extended_points = points.into_iter().map(|P| &P.0);
+    DecafPoint(curve::multiscalar_mult(scalars, extended_points))
+}
 
 /// Precomputation
 #[derive(Clone)]

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -577,6 +577,26 @@ impl<'a, 'b> Mul<&'b DecafPoint> for &'a Scalar {
     }
 }
 
+/// Given a vector of (possibly secret) scalars and a vector of
+/// (possibly secret) points, compute `c_1 P_1 + ... + c_n P_n`.
+///
+/// This function has the same behaviour as
+/// `vartime::multiscalar_mult` but is constant-time.
+///
+/// # Input
+///
+/// A vector of `Scalar`s and a vector of `DecafPoints`.  It is an
+/// error to call this function with two vectors of different lengths.
+#[cfg(any(feature = "alloc", feature = "std"))]
+pub fn multiscalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> DecafPoint
+    where I: IntoIterator<Item = &'a Scalar>,
+          I::IntoIter: ExactSizeIterator,
+          J: IntoIterator<Item = &'b DecafPoint>,
+          J::IntoIter: ExactSizeIterator,
+{
+    let extended_points = points.into_iter().map(|P| &P.0);
+    DecafPoint(curve::multiscalar_mult(scalars, extended_points))
+}
 
 /// Precomputation
 #[derive(Clone)]
@@ -685,7 +705,9 @@ pub mod vartime {
     /// error to call this function with two vectors of different lengths.
     pub fn multiscalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> DecafPoint
         where I: IntoIterator<Item = &'a Scalar>,
-              J: IntoIterator<Item = &'b DecafPoint>
+              I::IntoIter: ExactSizeIterator,
+              J: IntoIterator<Item = &'b DecafPoint>,
+              J::IntoIter: ExactSizeIterator,
     {
         let extended_points = points.into_iter().map(|P| &P.0);
         DecafPoint(curve::vartime::multiscalar_mult(scalars, extended_points))

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -577,26 +577,6 @@ impl<'a, 'b> Mul<&'b DecafPoint> for &'a Scalar {
     }
 }
 
-/// Given a vector of (possibly secret) scalars and a vector of
-/// (possibly secret) points, compute `c_1 P_1 + ... + c_n P_n`.
-///
-/// This function has the same behaviour as
-/// `vartime::multiscalar_mult` but is constant-time.
-///
-/// # Input
-///
-/// A vector of `Scalar`s and a vector of `DecafPoints`.  It is an
-/// error to call this function with two vectors of different lengths.
-#[cfg(any(feature = "alloc", feature = "std"))]
-pub fn multiscalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> DecafPoint
-    where I: IntoIterator<Item = &'a Scalar>,
-          I::IntoIter: ExactSizeIterator,
-          J: IntoIterator<Item = &'b DecafPoint>,
-          J::IntoIter: ExactSizeIterator,
-{
-    let extended_points = points.into_iter().map(|P| &P.0);
-    DecafPoint(curve::multiscalar_mult(scalars, extended_points))
-}
 
 /// Precomputation
 #[derive(Clone)]
@@ -705,9 +685,7 @@ pub mod vartime {
     /// error to call this function with two vectors of different lengths.
     pub fn multiscalar_mult<'a, 'b, I, J>(scalars: I, points: J) -> DecafPoint
         where I: IntoIterator<Item = &'a Scalar>,
-              I::IntoIter: ExactSizeIterator,
-              J: IntoIterator<Item = &'b DecafPoint>,
-              J::IntoIter: ExactSizeIterator,
+              J: IntoIterator<Item = &'b DecafPoint>
     {
         let extended_points = points.into_iter().map(|P| &P.0);
         DecafPoint(curve::vartime::multiscalar_mult(scalars, extended_points))

--- a/src/field.rs
+++ b/src/field.rs
@@ -202,12 +202,18 @@ impl<'a, 'b> Mul<&'b FieldElement> for &'a FieldElement {
         let a: &[u64; 5] = &self.0;
         let b: &[u64; 5] = &_rhs.0;
 
+        // 64-bit precomputations
+        let b1_19 = b[1] * 19;
+        let b2_19 = b[2] * 19;
+        let b3_19 = b[3] * 19;
+        let b4_19 = b[4] * 19;
+
         // Multiply to get 128-bit coefficients of output
-        let     c0: u128 = m(a[0],b[0]) + ( m(a[4],b[1]) +   m(a[3],b[2]) +   m(a[2],b[3]) +   m(a[1],b[4]) )*19;
-        let mut c1: u128 = m(a[1],b[0]) +   m(a[0],b[1]) + ( m(a[4],b[2]) +   m(a[3],b[3]) +   m(a[2],b[4]) )*19;
-        let mut c2: u128 = m(a[2],b[0]) +   m(a[1],b[1]) +   m(a[0],b[2]) + ( m(a[4],b[3]) +   m(a[3],b[4]) )*19;
-        let mut c3: u128 = m(a[3],b[0]) +   m(a[2],b[1]) +   m(a[1],b[2]) +   m(a[0],b[3]) + ( m(a[4],b[4]) )*19;
-        let mut c4: u128 = m(a[4],b[0]) +   m(a[3],b[1]) +   m(a[2],b[2]) +   m(a[1],b[3]) +   m(a[0],b[4]);
+        let     c0: u128 = m(a[0],b[0]) + m(a[4],b1_19) + m(a[3],b2_19) + m(a[2],b3_19) + m(a[1],b4_19);
+        let mut c1: u128 = m(a[1],b[0]) + m(a[0],b[1])  + m(a[4],b2_19) + m(a[3],b3_19) + m(a[2],b4_19);
+        let mut c2: u128 = m(a[2],b[0]) + m(a[1],b[1])  + m(a[0],b[2])  + m(a[4],b3_19) + m(a[3],b4_19);
+        let mut c3: u128 = m(a[3],b[0]) + m(a[2],b[1])  + m(a[1],b[2])  + m(a[0],b[3])  + m(a[4],b4_19);
+        let mut c4: u128 = m(a[4],b[0]) + m(a[3],b[1])  + m(a[2],b[2])  + m(a[1],b[3])  + m(a[0],b[4]);
 
         // Now c[i] < 2^2b * (1+i + (4-i)*19) < 2^(2b + lg(1+4*19)) < 2^(2b + 6.27)
         // where b is the bitlength of the input limbs.


### PR DESCRIPTION
This provides a constant-time version of the `k_fold_scalar_mult` function already in the `vartime` module.

Question: are we happy with the name? Does the `vartime::` submodule effectively separate two functions that do the same thing, but one is constant-time?