### PR TITLE
Bump subtle dependency to ^0.2 and use new API.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ version = "0.3"
 version = "0.6"
 
 [dependencies.subtle]
-version = "^0.1"
+version = "^0.2"
 default-features = false
 
 [dependencies.generic-array]
@@ -47,7 +47,7 @@ version = "0.6"
 version = "0.6"
 
 [features]
-nightly = ["radix_51"]
+nightly = ["radix_51", "subtle/nightly"]
 default = ["std"]
 std = ["rand", "subtle/std"]
 alloc = []

--- a/src/decaf.rs
+++ b/src/decaf.rs
@@ -32,8 +32,6 @@ use generic_array::typenum::U32;
 
 use constants;
 use field::FieldElement;
-use subtle::CTAssignable;
-use subtle::CTNegatable;
 
 use core::ops::{Add, Sub, Neg};
 use core::ops::{AddAssign, SubAssign};
@@ -45,6 +43,9 @@ use curve::CompletedPoint;
 use curve::EdwardsBasepointTable;
 use curve::Identity;
 use scalar::Scalar;
+
+use subtle::ConditionallyAssignable;
+use subtle::ConditionallyNegatable;
 
 // ------------------------------------------------------------------------
 // Compressed points
@@ -631,7 +632,7 @@ impl DecafBasepointTable {
 // Constant-time conditional assignment
 // ------------------------------------------------------------------------
 
-impl CTAssignable for DecafPoint {
+impl ConditionallyAssignable for DecafPoint {
     /// Conditionally assign `other` to `self`, if `choice == 1u8`.
     ///
     /// # Example
@@ -640,7 +641,7 @@ impl CTAssignable for DecafPoint {
     /// # extern crate subtle;
     /// # extern crate curve25519_dalek;
     /// #
-    /// # use subtle::CTAssignable;
+    /// # use subtle::ConditionallyAssignable;
     /// #
     /// # use curve25519_dalek::curve::Identity;
     /// # use curve25519_dalek::decaf::DecafPoint;

--- a/src/field.rs
+++ b/src/field.rs
@@ -22,10 +22,10 @@
 
 use core::cmp::{Eq, PartialEq};
 
-use subtle::arrays_equal;
+use subtle::slices_equal;
 use subtle::byte_is_nonzero;
-use subtle::CTAssignable;
-use subtle::CTEq;
+use subtle::ConditionallyAssignable;
+use subtle::Equal;
 
 use constants;
 
@@ -62,7 +62,7 @@ impl PartialEq for FieldElement {
     }
 }
 
-impl CTEq for FieldElement {
+impl Equal for FieldElement {
     /// Test equality between two `FieldElement`s.  Since the
     /// internal representation is not canonical, the field elements
     /// are normalized to wire format before comparison.
@@ -71,7 +71,7 @@ impl CTEq for FieldElement {
     ///
     /// `1u8` if the two `FieldElement`s are equal, and `0u8` otherwise.
     fn ct_eq(&self, other: &FieldElement) -> u8 {
-        arrays_equal(&self.to_bytes(), &other.to_bytes())
+        slices_equal(&self.to_bytes(), &other.to_bytes())
     }
 }
 
@@ -323,7 +323,7 @@ impl FieldElement {
 #[cfg(test)]
 mod test {
     use field::*;
-    use subtle::CTNegatable;
+    use subtle::ConditionallyNegatable;
 
     /// Random element a of GF(2^255-19), from Sage
     /// a = 1070314506888354081329385823235218444233221\

--- a/src/field_32bit.rs
+++ b/src/field_32bit.rs
@@ -30,7 +30,7 @@ use core::ops::{Sub, SubAssign};
 use core::ops::{Mul, MulAssign};
 use core::ops::Neg;
 
-use subtle::CTAssignable;
+use subtle::ConditionallyAssignable;
 
 use utils::{load3, load4};
 
@@ -189,7 +189,7 @@ impl<'a> Neg for &'a FieldElement32 {
     }
 }
 
-impl CTAssignable for FieldElement32 {
+impl ConditionallyAssignable for FieldElement32 {
     fn conditional_assign(&mut self, f: &FieldElement32, choice: u8) {
         let mask = -(choice as i32);
         for i in 0..10 {

--- a/src/field_64bit.rs
+++ b/src/field_64bit.rs
@@ -25,7 +25,7 @@ use core::ops::{Sub, SubAssign};
 use core::ops::{Mul, MulAssign};
 use core::ops::Neg;
 
-use subtle::CTAssignable;
+use subtle::ConditionallyAssignable;
 
 use utils::load8;
 
@@ -166,7 +166,7 @@ impl<'a> Neg for &'a FieldElement64 {
     }
 }
 
-impl CTAssignable for FieldElement64 {
+impl ConditionallyAssignable for FieldElement64 {
     fn conditional_assign(&mut self, f: &FieldElement64, choice: u8) {
         let mask = (-(choice as i64)) as u64;
         for i in 0..5 {

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -45,9 +45,10 @@ use generic_array::typenum::U64;
 
 use constants;
 use utils::{load3, load4};
-use subtle::CTAssignable;
-use subtle::CTEq;
-use subtle::arrays_equal;
+
+use subtle::slices_equal;
+use subtle::ConditionallyAssignable;
+use subtle::Equal;
 
 /// The `Scalar` struct represents an element in ℤ/lℤ, where
 ///
@@ -76,18 +77,18 @@ impl PartialEq for Scalar {
     ///
     /// True if they are equal, and false otherwise.
     fn eq(&self, other: &Self) -> bool {
-        arrays_equal(&self.0, &other.0) == 1u8
+        slices_equal(&self.0, &other.0) == 1u8
     }
 }
 
-impl CTEq for Scalar {
+impl Equal for Scalar {
     /// Test equality between two `Scalar`s in constant time.
     ///
     /// # Returns
     ///
     /// `1u8` if they are equal, and `0u8` otherwise.
     fn ct_eq(&self, other: &Self) -> u8 {
-        arrays_equal(&self.0, &other.0)
+        slices_equal(&self.0, &other.0)
     }
 }
 
@@ -154,14 +155,14 @@ impl<'a> Neg for &'a Scalar {
     }
 }
 
-impl CTAssignable for Scalar {
+impl ConditionallyAssignable for Scalar {
     /// Conditionally assign another Scalar to this one.
     ///
     /// ```
     /// # extern crate curve25519_dalek;
     /// # extern crate subtle;
     /// # use curve25519_dalek::scalar::Scalar;
-    /// # use subtle::CTAssignable;
+    /// # use subtle::ConditionallyAssignable;
     /// # fn main() {
     /// let a = Scalar([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
     ///                 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]);


### PR DESCRIPTION
This should bring some decent (~30%) speedups wherever `slices_equal` is used, which for us is all over the place, but usually we are comparing relatively small slices (~32 bytes) so the speedup is not as drastic as it is for larger slice comparisons.