### PR TITLE
Make FieldElement limbs private to the curve25519-dalek crate.

### DIFF
--- a/src/field_32bit.rs
+++ b/src/field_32bit.rs
@@ -56,7 +56,7 @@ use utils::{load3, load4};
 /// faster.  However, the `FieldElement64` implementation requires Rust's
 /// `u128`, which is not yet stable.
 #[derive(Copy, Clone)]
-pub struct FieldElement32(pub [i32; 10]);
+pub struct FieldElement32(pub (crate) [i32; 10]);
 
 impl Debug for FieldElement32 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {

--- a/src/field_64bit.rs
+++ b/src/field_64bit.rs
@@ -51,7 +51,7 @@ pub type Limb = u64;
 /// which gives even better performance.  This implementation requires Rust's
 /// `u128`, which is not yet stable.
 #[derive(Copy, Clone)]
-pub struct FieldElement64(pub [u64; 5]);
+pub struct FieldElement64(pub (crate) [u64; 5]);
 
 impl Debug for FieldElement64 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {


### PR DESCRIPTION
Limbs are no longer accessible outside of the curve25519-dalek crate.
If you were relying on this behaviour, first you probably shouldn't be
doing that, second please contact us so we can determine the best way
forward for your use case.

This works for rustc>=1.18.0.