### PR TITLE
Texify more formulas + Scalar API tweak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
+FEATURES := nightly yolocrypto
 
 doc:
-	cargo rustdoc --features "nightly yolocrypto" -- --html-in-header rustdoc-include-katex-header.html
+	cargo rustdoc --features "$(FEATURES)" -- --html-in-header rustdoc-include-katex-header.html
 
 doc-internal:
-	cargo rustdoc --features "nightly yolocrypto" -- --html-in-header rustdoc-include-katex-header.html --document-private-items
+	cargo rustdoc --features "$(FEATURES)" -- --html-in-header rustdoc-include-katex-header.html --document-private-items
 

--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@ doc:
 	cargo rustdoc --features "nightly yolocrypto" -- --html-in-header rustdoc-include-katex-header.html
 
 doc-internal:
-	cargo rustdoc --features "nightly yolocrypto" -- --html-in-header rustdoc-include-katex-header.html --no-defaults --passes "collapse-docs" --passes "unindent-comments"
+	cargo rustdoc --features "nightly yolocrypto" -- --html-in-header rustdoc-include-katex-header.html --document-private-items
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -22,11 +22,9 @@
 //! `32bit` since identifiers can't start with letters, and the backends
 //! do use `u32`/`u64`, so this seems like a least-bad option.
 
-/// Code using `u32`s and a `(u32, u32) -> u64` multiplier.
 #[cfg(not(feature="radix_51"))]
 pub mod u32;
 
-/// Code using `u64`s and a `(u64, u64) -> u128` multiplier.
 #[cfg(feature="radix_51")]
 pub mod u64;
 

--- a/src/backend/u32/mod.rs
+++ b/src/backend/u32/mod.rs
@@ -8,6 +8,12 @@
 // - Isis Agora Lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
+//! The `u32` backend uses `u32`s and a `(u32, u32) -> u64` multiplier.
+//! 
+//! This code is intended to be portable, but it requires that
+//! multiplication of two \\(32\\)-bit values to a \\(64\\)-bit result
+//! is constant-time on the target platform.
+
 pub mod field;
 
 pub mod scalar;

--- a/src/backend/u64/constants.rs
+++ b/src/backend/u64/constants.rs
@@ -8,9 +8,7 @@
 // - Isis Agora Lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
-//! This module contains various constants (such as curve parameters
-//! and useful field elements like `sqrt(-1)`), as well as
-//! lookup tables of pre-computed points.
+//! This module contains backend-specific constant values, such as the 64-bit limbs of curve constants.
 
 use backend::u64::field::FieldElement64;
 use backend::u64::scalar::Scalar64;

--- a/src/backend/u64/field.rs
+++ b/src/backend/u64/field.rs
@@ -8,14 +8,8 @@
 // - Isis Agora Lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
-//! Field arithmetic for ℤ/(2²⁵⁵-19), using 64-bit arithmetic wuth
-//! 128-bit products.
-//!
-//! On x86_64, the multiplications lower to `MUL` instructions taking
-//! 64-bit inputs and producing 128-bit outputs.  On other platforms,
-//! this implementation is not recommended.  On Haswell and newer, the
-//! BMI2 instruction set provides `MULX` and friends, which gives even
-//! better performance.
+//! Field arithmetic modulo \\(p = 2\^{255} - 19\\), using \\(64\\)-bit
+//! limbs with \\(128\\)-bit products.
 
 use core::fmt::Debug;
 use core::ops::{Add, AddAssign};
@@ -25,25 +19,21 @@ use core::ops::Neg;
 
 use subtle::ConditionallyAssignable;
 
-/// A `FieldElement64` represents an element of the field GF(2^255 - 19).
+/// A `FieldElement64` represents an element of the field
+/// \\( \mathbb Z / (2\^{255} - 19)\\).
 ///
 /// In the 64-bit implementation, a `FieldElement` is represented in
-/// radix 2^51 as five `u64`s; the coefficients are allowed to grow up
-/// to 2^54 between reductions mod `p`.
+/// radix \\(2\^{51}\\) as five `u64`s; the coefficients are allowed to
+/// grow up to \\(2\^{54}\\) between reductions modulo \\(p\\).
 ///
-/// # Warning
-///
-/// You almost certainly do not want to use `FieldElement64` directly.  Consider
-/// using `curve25519_dalek::field::FieldElement`, which will automatically
-/// select between `FieldElement32` and `FieldElement64` depending on whether
-/// curve25519-dalek was compiled with `--features="nightly"`.
-///
-/// This implementation, `FieldElement64`, is intended for x64_64 platforms,
-/// which have the `MUL` instructions taking 64-bit inputs and producing 128-bit
-/// outputs.  On other platforms, this implementation is not recommended.  On
-/// Haswell and newer, the BMI2 instruction set provides `MULX` and friends,
-/// which gives even better performance.  This implementation requires Rust's
-/// `u128`, which is not yet stable.
+/// # Note
+/// 
+/// The `curve25519_dalek::field` module provides a type alias
+/// `curve25519_dalek::field::FieldElement` to either `FieldElement64`
+/// or `FieldElement32`.
+/// 
+/// The backend-specific type `FieldElement64` should not be used
+/// outside of the `curve25519_dalek::field` module.
 #[derive(Copy, Clone)]
 pub struct FieldElement64(pub (crate) [u64; 5]);
 

--- a/src/backend/u64/mod.rs
+++ b/src/backend/u64/mod.rs
@@ -8,6 +8,17 @@
 // - Isis Agora Lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
+//! The `u64` backend uses `u64`s and a `(u64, u64) -> u128` multiplier.
+//! 
+//! On x86_64, the idiom `(x as u128) * (y as u128)` lowers to `MUL`
+//! instructions taking 64-bit inputs and producing 128-bit outputs.  On
+//! other platforms, this implementation is not recommended. 
+//! 
+//! On Haswell and newer, the BMI2 extension provides `MULX`, and on
+//! Broadwell and newer, the ADX extension provides `ADCX` and `ADOX`
+//! (allowing the CPU to compute two carry chains in parallel).  These
+//! will be used if available.
+
 pub mod field;
 
 pub mod scalar;

--- a/src/backend/u64/scalar.rs
+++ b/src/backend/u64/scalar.rs
@@ -1,19 +1,23 @@
-//! Arithmetic mod 2^252 + 27742317777372353535851937790883648493
-//! with 5 52-bit unsigned limbs. 51-bit limbs would cover the
-//! desired bit range (253 bits), but isn't large enough to reduce
-//! a 512 bit number with Montgomery multiplication, so 52 bits is
-//! used instead
+//! Arithmetic mod \\(2\^{252} + 27742317777372353535851937790883648493\\)
+//! with five \\(52\\)-bit unsigned limbs.
 //!
-//! To see that this is safe for intermediate results, note that
-//! the largest limb in a 5 by 5 product of 52-bit limbs will be
+//! \\(51\\)-bit limbs would cover the desired bit range (\\(253\\)
+//! bits), but isn't large enough to reduce a \\(512\\)-bit number with
+//! Montgomery multiplication, so \\(52\\) bits is used instead.  To see
+//! that this is safe for intermediate results, note that the largest
+//! limb in a \\(5\times 5\\) product of \\(52\\)-bit limbs will be
+//!
+//! ```text
 //! (0xfffffffffffff^2) * 5 = 0x4ffffffffffff60000000000005 (107 bits).
+//! ```
 
 use core::fmt::Debug;
 use core::ops::{Index, IndexMut};
 
 use constants;
 
-/// The `Scalar64` struct represents an element in ℤ/lℤ as 5 52-bit limbs
+/// The `Scalar64` struct represents an element in 
+/// \\(\mathbb Z / \ell \mathbb Z\\) as 5 \\(52\\)-bit limbs.
 #[derive(Copy,Clone)]
 pub struct Scalar64(pub [u64; 5]);
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -8,9 +8,7 @@
 // - Isis Agora Lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
-//! This module contains various constants (such as curve parameters
-//! and useful field elements like `sqrt(-1)`), as well as
-//! lookup tables of pre-computed points.
+//! This module contains various constants, such as the Ristretto and Ed25519 basepoints.
 //!
 //! Most of the constants are given with
 //! `LONG_DESCRIPTIVE_UPPER_CASE_NAMES`, but they can be brought into

--- a/src/curve_models/mod.rs
+++ b/src/curve_models/mod.rs
@@ -347,8 +347,13 @@ impl ProjectivePoint {
 // Addition and Subtraction
 // ------------------------------------------------------------------------
 
-// These are doc(hidden) so they don't appear in the public API docs.
-#[doc(hidden)]
+// XXX(hdevalence) These were doc(hidden) so they don't appear in the
+// public API docs.
+// However, that prevents them being used with --document-private-items,
+// so comment out the doc(hidden) for now until this is resolved
+//
+// upstream rust issue: https://github.com/rust-lang/rust/issues/46380
+//#[doc(hidden)]
 impl<'a, 'b> Add<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
@@ -370,7 +375,7 @@ impl<'a, 'b> Add<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
     }
 }
 
-#[doc(hidden)]
+//#[doc(hidden)]
 impl<'a, 'b> Sub<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
@@ -392,7 +397,7 @@ impl<'a, 'b> Sub<&'b ProjectiveNielsPoint> for &'a ExtendedPoint {
     }
 }
 
-#[doc(hidden)]
+//#[doc(hidden)]
 impl<'a, 'b> Add<&'b AffineNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 
@@ -413,7 +418,7 @@ impl<'a, 'b> Add<&'b AffineNielsPoint> for &'a ExtendedPoint {
     }
 }
 
-#[doc(hidden)]
+//#[doc(hidden)]
 impl<'a, 'b> Sub<&'b AffineNielsPoint> for &'a ExtendedPoint {
     type Output = CompletedPoint;
 

--- a/src/curve_models/mod.rs
+++ b/src/curve_models/mod.rs
@@ -138,8 +138,13 @@ use traits::ValidityCheck;
 // Internal point representations
 // ------------------------------------------------------------------------
 
-/// A `ProjectivePoint` is a point on the curve in 𝗣²(𝔽ₚ).
-/// A point (x,y) in the affine model corresponds to (x:y:1).
+/// A `ProjectivePoint` is a point \\((X:Y:Z)\\) on the \\(\mathbb
+/// P\^2\\) model of the curve.
+/// A point \\((x,y)\\) in the affine model corresponds to
+/// \\((x:y:1)\\).
+///
+/// More details on the relationships between the different curve models
+/// can be found in the module-level documentation.
 #[derive(Copy, Clone)]
 pub struct ProjectivePoint {
     pub X: FieldElement,
@@ -147,8 +152,13 @@ pub struct ProjectivePoint {
     pub Z: FieldElement,
 }
 
-/// A `CompletedPoint` is a point ((X:Z), (Y:T)) in 𝗣¹(𝔽ₚ)×𝗣¹(𝔽ₚ).
-/// A point (x,y) in the affine model corresponds to ((x:1),(y:1)).
+/// A `CompletedPoint` is a point \\(((X:Z), (Y:T))\\) on the \\(\mathbb
+/// P\^1 \times \mathbb P\^1 \\) model of the curve.
+/// A point (x,y) in the affine model corresponds to \\( ((x:1),(y:1))
+/// \\).
+///
+/// More details on the relationships between the different curve models
+/// can be found in the module-level documentation.
 #[derive(Copy, Clone)]
 #[allow(missing_docs)]
 pub struct CompletedPoint {
@@ -159,9 +169,10 @@ pub struct CompletedPoint {
 }
 
 /// A pre-computed point in the affine model for the curve, represented as
-/// (y+x, y-x, 2dxy).  These precomputations accelerate addition and
-/// subtraction, and were introduced by Niels Duif in the ed25519 paper
-/// ["High-Speed High-Security Signatures"](https://ed25519.cr.yp.to/ed25519-20110926.pdf).
+/// \\((y+x, y-x, 2dxy)\\) in "Niels coordinates".
+///
+/// More details on the relationships between the different curve models
+/// can be found in the module-level documentation.
 // Safe to derive Eq because affine coordinates.
 #[derive(Copy, Clone, Eq, PartialEq)]
 #[allow(missing_docs)]
@@ -171,10 +182,11 @@ pub struct AffineNielsPoint {
     pub xy2d:      FieldElement,
 }
 
-/// A pre-computed point in the P³(𝔽ₚ) model for the curve, represented as
-/// (Y+X, Y-X, Z, 2dXY).  These precomputations accelerate addition and
-/// subtraction, and were introduced by Niels Duif in the ed25519 paper
-/// ["High-Speed High-Security Signatures"](https://ed25519.cr.yp.to/ed25519-20110926.pdf).
+/// A pre-computed point on the \\( \mathbb P\^3 \\) model for the
+/// curve, represented as \\((Y+X, Y-X, Z, 2dXY)\\) in "Niels coordinates".
+///
+/// More details on the relationships between the different curve models
+/// can be found in the module-level documentation.
 #[derive(Copy, Clone)]
 pub struct ProjectiveNielsPoint {
     pub Y_plus_X:  FieldElement,
@@ -266,14 +278,10 @@ impl ConditionallyAssignable for AffineNielsPoint {
 // ------------------------------------------------------------------------
 
 impl ProjectivePoint {
-    /// Convert to the extended twisted Edwards representation of this
-    /// point.
+    /// Convert this point from the \\( \mathbb P\^2 \\) model to the
+    /// \\( \mathbb P\^3 \\) model.
     ///
-    /// From §3 in [0]:
-    ///
-    /// Given (X:Y:Z) in Ɛ, passing to Ɛₑ can be performed in 3M+1S by
-    /// computing (XZ,YZ,XY,Z²).  (Note that in that paper, points are
-    /// (X:Y:T:Z) so this really does match the code below).
+    /// This costs \\(3 \mathrm M + 1 \mathrm S\\).
     pub fn to_extended(&self) -> ExtendedPoint {
         ExtendedPoint{
             X: &self.X * &self.Z,
@@ -285,7 +293,10 @@ impl ProjectivePoint {
 }
 
 impl CompletedPoint {
-    /// Convert to a ProjectivePoint
+    /// Convert this point from the \\( \mathbb P\^1 \times \mathbb P\^1
+    /// \\) model to the \\( \mathbb P\^2 \\) model.
+    ///
+    /// This costs \\(3 \mathrm M \\).
     pub fn to_projective(&self) -> ProjectivePoint {
         ProjectivePoint{
             X: &self.X * &self.T,
@@ -294,7 +305,10 @@ impl CompletedPoint {
         }
     }
 
-    /// Convert to an ExtendedPoint
+    /// Convert this point from the \\( \mathbb P\^1 \times \mathbb P\^1
+    /// \\) model to the \\( \mathbb P\^3 \\) model.
+    ///
+    /// This costs \\(4 \mathrm M \\).
     pub fn to_extended(&self) -> ExtendedPoint {
         ExtendedPoint{
             X: &self.X * &self.T,

--- a/src/field.rs
+++ b/src/field.rs
@@ -8,15 +8,19 @@
 // - Isis Agora Lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
-//! Field arithmetic for ℤ/(2²⁵⁵-19).
+//! Field arithmetic modulo \\(p = 2\^{255} - 19\\).
 //!
-//! Partially based on Adam Langley's curve25519-donna and (Golang)
-//! ed25519 implementations, with other techniques inspired by Mike
-//! Hamburg's code.
+//! The `curve25519_dalek::field` module provides a type alias
+//! `curve25519_dalek::field::FieldElement` to a field element type
+//! defined in the `backend` module; either `FieldElement64` or
+//! `FieldElement32`.
 //!
-//! This module re-exports either the 32-bit or 64-bit implementation,
-//! and implements functions that are generic with respect to the
-//! basic operations, such as inverses and square roots.
+//! Field operations defined in terms of machine
+//! operations, such as field multiplication or squaring, are defined in
+//! the backend implementation.
+//!
+//! Field operations defined in terms of other field operations, such as
+//! field inversion or square roots, are defined here.
 
 use core::cmp::{Eq, PartialEq};
 
@@ -31,13 +35,21 @@ use backend;
 
 #[cfg(feature="radix_51")]
 pub use backend::u64::field::*;
-/// A `FieldElement` represents an element of the field GF(2^255 - 19).
+/// A `FieldElement` represents an element of the field
+/// \\( \mathbb Z / (2\^{255} - 19)\\).
+///
+/// The `FieldElement` type is an alias for one of the platform-specific
+/// implementations.
 #[cfg(feature="radix_51")]
 pub type FieldElement = backend::u64::field::FieldElement64;
 
 #[cfg(not(feature="radix_51"))]
 pub use backend::u32::field::*;
-/// A `FieldElement` represents an element of the field GF(2^255 - 19).
+/// A `FieldElement` represents an element of the field
+/// \\( \mathbb Z / (2\^{255} - 19)\\).
+///
+/// The `FieldElement` type is an alias for one of the platform-specific
+/// implementations.
 #[cfg(not(feature="radix_51"))]
 pub type FieldElement = backend::u32::field::FieldElement32;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,7 @@
 
 //! # curve25519-dalek
 //!
-//! **A Rust implementation of field and group operations on an Edwards curve
-//! over GF(2^255 - 19).**
+//! **A high-performance, pure-Rust implementation of group operations for Ristretto and Curve25519.**
 //!
 //! **[SPOILER ALERT]** The Twelfth Doctor's first encounter with the Daleks is
 //! in his second full episode, "Into the Dalek".  A beleaguered ship of the

--- a/src/montgomery.rs
+++ b/src/montgomery.rs
@@ -8,7 +8,7 @@
 // - Isis Agora Lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
-//! Montgomery arithmetic.
+//! Group operations for Curve25519, in Montgomery form.
 //!
 //! Apart from the compressed point implementation
 //! (i.e. `CompressedMontgomeryU`), this module is a "clean room" implementation

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -512,11 +512,6 @@ impl Scalar {
         UnpackedScalar::from_bytes(&self.bytes)
     }
 
-    /// Compute `(a * b) + c` (mod l).
-    pub fn multiply_add(a: &Scalar, b: &Scalar, c: &Scalar) -> Scalar {
-        UnpackedScalar::add(&UnpackedScalar::mul(&a.unpack(), &b.unpack()), &c.unpack()).pack()
-    }
-
     /// Reduce this `Scalar` modulo \\(\ell\\).
     pub fn reduce(&self) -> Scalar {
         let x = self.unpack();
@@ -759,9 +754,7 @@ mod test {
 
     #[test]
     fn scalar_multiply_by_one() {
-        let one = Scalar::one();
-        let zero = Scalar::zero();
-        let test_scalar = Scalar::multiply_add(&X, &one, &zero);
+        let test_scalar = &X * &Scalar::one();
         for i in 0..32 {
             assert!(test_scalar[i] == X[i]);
         }
@@ -789,16 +782,8 @@ mod test {
     }
 
     #[test]
-    fn scalar_multiply_add() {
-        let test_scalar = Scalar::multiply_add(&X, &Y, &Z);
-        for i in 0..32 {
-            assert!(test_scalar[i] == W[i]);
-        }
-    }
-
-    #[test]
     fn square() {
-        let expected = Scalar::multiply_add(&X, &X, &Scalar::zero());
+        let expected = &X * &X;
         let actual = X.unpack().square().pack();
         for i in 0..32 {
             assert!(expected[i] == actual[i]);

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -62,8 +62,11 @@ type UnpackedScalar = backend::u32::scalar::Scalar32;
 /// To create a `Scalar` from a supposedly canonical encoding, use
 /// `Scalar::from_canonical_bytes`.
 ///
-/// To create a `Scalar` by reducing a 256-bit integer mod \\( \ell \\),
+/// To create a `Scalar` by reducing a \\(256\\)-bit integer mod \\( \ell \\),
 /// use `Scalar::from_bytes_mod_order`.
+///
+/// To create a `Scalar` by reducing a \\(512\\)-bit integer mod \\( \ell \\),
+/// use `Scalar::from_bytes_mod_order_wide`.
 ///
 /// To create a `Scalar` with a specific bit-pattern (e.g., for
 /// compatibility with X25519 "clamping"), use `Scalar::from_bits`.

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -10,29 +10,7 @@
 // - Henry de Valence <hdevalence@hdevalence.ca>
 // - Brian Smith <brian@briansmith.org>
 
-//! Arithmetic on scalars.
-//!
-//! Both the Ristretto group and the Ed25519 basepoint have prime order
-//! \\( \ell = 2\^{252} + 27742317777372353535851937790883648493 \\).
-//!
-//! The `Scalar` struct holds an integer \\(s < 2\^{255} \\) which
-//! represents an element of \\(\mathbb Z / \ell\\).
-//!
-//! The code is intended to be useful with both the Ristretto group
-//! (where everything is done modulo \\( \ell \\), and the X/Ed25519
-//! setting, which mandates specific bit-twiddles that are not
-//! well-defined modulo \\( \ell \\).
-//!
-//! To create a `Scalar` from a supposedly canonical encoding, use
-//! `Scalar::from_canonical_bytes`.
-//!
-//! To create a `Scalar` by reducing a 256-bit integer mod \\( \ell \\),
-//! use `Scalar::from_bytes_mod_order`.
-//!
-//! To create a `Scalar` with a specific bit-pattern (e.g., for
-//! compatibility with X25519 "clamping"), use `Scalar::from_bits`.
-//!
-//! All arithmetic on `Scalars` is done modulo \\( \ell \\).
+//! Arithmetic on scalars (integers mod the group order).
 
 use core::fmt::Debug;
 use core::ops::Neg;
@@ -70,11 +48,27 @@ type UnpackedScalar = backend::u64::scalar::Scalar64;
 type UnpackedScalar = backend::u32::scalar::Scalar32;
 
 
-/// The `Scalar` struct represents an element in ℤ/lℤ, where
+/// The `Scalar` struct holds an integer \\(s < 2\^{255} \\) which
+/// represents an element of \\(\mathbb Z / \ell\\).
 ///
-/// l = 2^252 + 27742317777372353535851937790883648493
+/// Both the Ristretto group and the Ed25519 basepoint have prime order
+/// \\( \ell = 2\^{252} + 27742317777372353535851937790883648493 \\).
 ///
-/// is the order of the basepoint.  The `Scalar` is stored as bytes.
+/// The code is intended to be useful with both the Ristretto group
+/// (where everything is done modulo \\( \ell \\)), and the X/Ed25519
+/// setting, which mandates specific bit-twiddles that are not
+/// well-defined modulo \\( \ell \\).
+///
+/// To create a `Scalar` from a supposedly canonical encoding, use
+/// `Scalar::from_canonical_bytes`.
+///
+/// To create a `Scalar` by reducing a 256-bit integer mod \\( \ell \\),
+/// use `Scalar::from_bytes_mod_order`.
+///
+/// To create a `Scalar` with a specific bit-pattern (e.g., for
+/// compatibility with X25519 "clamping"), use `Scalar::from_bits`.
+///
+/// All arithmetic on `Scalars` is done modulo \\( \ell \\).
 #[derive(Copy, Clone)]
 pub struct Scalar {
     /// `bytes` is a little-endian byte encoding of an integer representing a scalar modulo the group order.
@@ -88,8 +82,9 @@ pub struct Scalar {
 }
 
 impl Scalar {
-    /// Construct a `Scalar` by reducing a 256-bit integer modulo the group order.
-    pub fn from_bytes_mod_order(bytes: [u8;32]) -> Scalar {
+    /// Construct a `Scalar` by reducing a 256-bit little-endian integer
+    /// modulo the group order \\( \ell \\).
+    pub fn from_bytes_mod_order(bytes: [u8; 32]) -> Scalar {
         // Temporarily allow s_unreduced.bytes > 2^255 ...
         let s_unreduced = Scalar{bytes: bytes};
 
@@ -381,12 +376,12 @@ impl Scalar {
         &self.bytes
     }
 
-    /// Construct the additive identity
+    /// Construct the scalar \\( 0 \\).
     pub fn zero() -> Self {
         Scalar { bytes: [0u8; 32]}
     }
 
-    /// Construct the multiplicative identity
+    /// Construct the scalar \\( 1 \\).
     pub fn one() -> Self {
         Scalar {
             bytes: [
@@ -423,14 +418,17 @@ impl Scalar {
 
     /// Compute a width-5 "Non-Adjacent Form" of this scalar.
     ///
-    /// A width-`w` NAF of a positive integer `k` is an expression
-    /// `k = sum(k[i]*2^i for i in range(l))`, where each nonzero
-    /// coefficient `k[i]` is odd and bounded by `|k[i]| < 2^(w-1)`,
-    /// `k[l-1]` is nonzero, and at most one of any `w` consecutive
+    /// A width-\\(w\\) NAF of a positive integer \\(k\\) is an expression
+    /// $$
+    /// k = \sum_{i=0}\^n k\_i 2\^i,
+    /// $$
+    /// where each nonzero
+    /// coefficient \\(k\_i\\) is odd and bounded by \\(|k\_i| < 2\^{w-1}\\),
+    /// \\(k\_{n-1}\\) is nonzero, and at most one of any \\(w\\) consecutive
     /// coefficients is nonzero.  (Hankerson, Menezes, Vanstone; def 3.32).
     ///
     /// Intuitively, this is like a binary expansion, except that we
-    /// allow some coefficients to grow up to `2^(w-1)` so that the
+    /// allow some coefficients to grow up to \\(2\^{w-1}\\) so that the
     /// nonzero coefficients are as sparse as possible.
     pub(crate) fn non_adjacent_form(&self) -> [i8; 256] {
         // Step 1: write out bits of the scalar
@@ -468,15 +466,12 @@ impl Scalar {
         naf
     }
 
-    /// Write this scalar in radix 16, with coefficients in `[-8,8)`,
-    /// i.e., compute `a_i` such that
-    ///
-    ///    a = a_0 + a_1*16^1 + ... + a_63*16^63,
-    ///
-    /// with `-8 ≤ a_i < 8` for `0 ≤ i < 63` and `-8 ≤ a_63 ≤ 8`.
-    ///
-    /// Precondition: self[31] <= 127.  This is the case whenever
-    /// `self` is reduced.
+    /// Write this scalar in radix 16, with coefficients in \\([-8,8)\\),
+    /// i.e., compute \\(a\_i\\) such that
+    /// $$
+    ///    a = a\_0 + a\_1 16\^1 + \cdots + a_{63} 16\^{63},
+    /// $$
+    /// with \\(-8 \leq a_i < 8\\) for \\(0 \leq i < 63\\) and \\(-8 \leq a_63 \leq 8\\).
     pub(crate) fn to_radix_16(&self) -> [i8; 64] {
         debug_assert!(self[31] <= 127);
         let mut output = [0i8; 64];
@@ -506,7 +501,7 @@ impl Scalar {
         output
     }
 
-    /// Unpack this `Scalar` to an `UnpackedScalar`
+    /// Unpack this `Scalar` to an `UnpackedScalar` for faster arithmetic.
     pub(crate) fn unpack(&self) -> UnpackedScalar {
         UnpackedScalar::from_bytes(&self.bytes)
     }
@@ -516,7 +511,7 @@ impl Scalar {
         UnpackedScalar::add(&UnpackedScalar::mul(&a.unpack(), &b.unpack()), &c.unpack()).pack()
     }
 
-    /// Reduce this `Scalar` mod l.
+    /// Reduce this `Scalar` modulo \\(\ell\\).
     pub fn reduce(&self) -> Scalar {
         let x = self.unpack();
         let xR = UnpackedScalar::mul_internal(&x, &constants::R);

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -10,7 +10,7 @@
 // - Henry de Valence <hdevalence@hdevalence.ca>
 // - Brian Smith <brian@briansmith.org>
 
-//! Arithmetic for scalar multiplication.
+//! Arithmetic on scalars.
 //!
 //! Both the Ristretto group and the Ed25519 basepoint have prime order
 //! \\( \ell = 2\^{252} + 27742317777372353535851937790883648493 \\).

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -75,7 +75,7 @@ pub struct Scalar {
     /// 
     /// # Invariant
     /// 
-    /// The integer representing this scalar must be bounded above by 2^255, or equivalently the high bit of `bytes[31]` must be zero.
+    /// The integer representing this scalar must be bounded above by \\(2\^{255}\\), or equivalently the high bit of `bytes[31]` must be zero.
     /// 
     // XXX This is pub(crate) so we can write literal constants.  If const fns were stable, we could make the Scalar constructors const fns and use those instead.
     pub(crate) bytes: [u8; 32],


### PR DESCRIPTION
This changeset converts more docs to use KaTeX.  Also there is a tweak to the `Scalar` API: `reduce_wide` is renamed to `from_bytes_mod_order_wide` to fit better with the other `Scalar` constructors.